### PR TITLE
Added ability for iOS receipt validation

### DIFF
--- a/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
@@ -140,13 +140,22 @@ namespace Plugin.InAppBilling
 
             var reference = new DateTime(2001, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
-            return new InAppBillingPurchase
-            {
-                TransactionDateUtc = reference.AddSeconds(p.TransactionDate.SecondsSinceReferenceDate),
-                Id = p.TransactionIdentifier,
-                ProductId = p.Payment?.ProductIdentifier ?? string.Empty,
-                State = p.GetPurchaseState()
-            };
+			// Get the receipt data for (server-side) validation.
+			// See: https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Introduction.html#//apple_ref/doc/uid/TP40010573
+			NSData r = NSData.FromUrl(NSBundle.MainBundle.AppStoreReceiptUrl);
+			string receipt = r.GetBase64EncodedString(NSDataBase64EncodingOptions.None);
+			if (verifyPurchase == null || await verifyPurchase.VerifyPurchase(receipt, string.Empty))
+			{
+				return new InAppBillingPurchase
+				{
+					TransactionDateUtc = reference.AddSeconds(p.TransactionDate.SecondsSinceReferenceDate),
+					Id = p.TransactionIdentifier,
+					ProductId = p.Payment?.ProductIdentifier ?? string.Empty,
+					State = p.GetPurchaseState()
+				};
+			}
+
+			return null;
         }
 
         Task<SKPaymentTransaction> PurchaseAsync(string productId)
@@ -190,9 +199,9 @@ namespace Plugin.InAppBilling
         /// <param name="purchaseToken">Original Purchase Token</param>
         /// <returns>If consumed successful</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
-        public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, string purchaseToken)
+		public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, string purchaseToken, IInAppBillingVerifyPurchase verifyPurchase)
         {
-            return PurchaseAsync(productId, ItemType.InAppPurchase, string.Empty);
+			return PurchaseAsync(productId, ItemType.InAppPurchase, string.Empty, verifyPurchase);
         }
 
         /// <summary>
@@ -206,7 +215,7 @@ namespace Plugin.InAppBilling
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
         public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase = null)
         {
-            return ConsumePurchaseAsync(productId, string.Empty);
+			return ConsumePurchaseAsync(productId, string.Empty, verifyPurchase);
         }
 
         PaymentObserver paymentObserver;

--- a/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
@@ -199,9 +199,9 @@ namespace Plugin.InAppBilling
         /// <param name="purchaseToken">Original Purchase Token</param>
         /// <returns>If consumed successful</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
-		public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, string purchaseToken, IInAppBillingVerifyPurchase verifyPurchase)
+		public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, string purchaseToken)
         {
-			return PurchaseAsync(productId, ItemType.InAppPurchase, string.Empty, verifyPurchase);
+			return PurchaseAsync(productId, ItemType.InAppPurchase, string.Empty);
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace Plugin.InAppBilling
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
         public Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase = null)
         {
-			return ConsumePurchaseAsync(productId, string.Empty, verifyPurchase);
+			return PurchaseAsync(productId, ItemType.InAppPurchase, string.Empty, verifyPurchase);
         }
 
         PaymentObserver paymentObserver;


### PR DESCRIPTION
Big :thumbsup: for your work!

Especially for auto-renewing subscriptions it is highly recommended (see [here](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/iTunesConnectInAppPurchase_Guide/Chapters/CreatingInAppPurchaseProducts.html#//apple_ref/doc/uid/TP40013727-CH3-SW2)) to validate the receipt; local or server-side, thus one could use the`IInAppBillingVerifyPurchase`-handler to call a remote or port that [beauty](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateLocally.html#//apple_ref/doc/uid/TP40010573-CH1-SW2) for receipt validation.

Changes Proposed in this pull request:
- Added `VerifyPurchase`-check to purchase method (iOS)