### PR TITLE
Typed exceptions

### DIFF
--- a/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
+++ b/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
@@ -42,7 +42,19 @@ namespace Plugin.InAppBilling.Abstractions
         /// <summary>
         /// One of hte payment parameters was not recognized by app store
         /// </summary>
-        PaymentInvalid
+        PaymentInvalid,
+        /// <summary>
+        /// The requested product is invalid
+        /// </summary>
+        InvalidProduct,
+        /// <summary>
+        /// The product request failed
+        /// </summary>
+        ProductRequestFailed,
+        /// <summary>
+        /// Restoring the transaction failed
+        /// </summary>
+        RestoreFailed
     }
 
     /// <summary>

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -41,6 +41,8 @@ namespace Plugin.InAppBilling
 
         const int PURCHASE_REQUEST_CODE = 1001;
 
+        const int RESPONSE_CODE_RESULT_USER_CANCELED = 1;
+
         Activity Context => CrossCurrentActivity.Current.Activity;
 
         /// <summary>
@@ -486,6 +488,10 @@ namespace Plugin.InAppBilling
                     DataSignature = dataSignature
                 });
 
+            }
+            else if (responseCode == RESPONSE_CODE_RESULT_USER_CANCELED)
+            {
+                tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
             }
             else
             {

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -270,10 +270,10 @@ namespace Plugin.InAppBilling
             if (tcsPurchase != null && !tcsPurchase.Task.IsCompleted)
                 return null;
 
+            tcsPurchase = new TaskCompletionSource<PurchaseResponse>();
 
             Bundle buyIntentBundle = serviceConnection.Service.GetBuyIntent(3, Context.PackageName, productSku, itemType, payload);
             var response = GetResponseCodeFromBundle(buyIntentBundle);
-
 
             switch (response)
             {
@@ -303,8 +303,6 @@ namespace Plugin.InAppBilling
                     return purchase;
                     //already purchased
             }
-
-            tcsPurchase = new TaskCompletionSource<PurchaseResponse>();
 
             var pendingIntent = buyIntentBundle.GetParcelable(RESPONSE_BUY_INTENT) as PendingIntent;
             if (pendingIntent != null)

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -42,13 +42,13 @@ namespace Plugin.InAppBilling
         const int PURCHASE_REQUEST_CODE = 1001;
 
         Activity Context => CrossCurrentActivity.Current.Activity;
-        
+
         /// <summary>
         /// Default Constructor for In App Billing Implemenation on Android
         /// </summary>
         public InAppBillingImplementation()
         {
-            
+
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Plugin.InAppBilling
                 throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
             }
 
-            IEnumerable <Product> products = null;
+            IEnumerable<Product> products = null;
             switch (itemType)
             {
                 case ItemType.InAppPurchase:
@@ -230,8 +230,9 @@ namespace Plugin.InAppBilling
         /// <returns></returns>
         public async override Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase = null)
         {
+            payload = payload ?? string.Empty;
 
-            if(serviceConnection.Service == null)
+            if (serviceConnection.Service == null)
             {
                 throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
             }
@@ -251,7 +252,7 @@ namespace Plugin.InAppBilling
                 return null;
 
             var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            
+
             return new InAppBillingPurchase
             {
                 TransactionDateUtc = epoch + TimeSpan.FromMilliseconds(purchase.PurchaseTime),
@@ -269,19 +270,19 @@ namespace Plugin.InAppBilling
             if (tcsPurchase != null && !tcsPurchase.Task.IsCompleted)
                 return null;
 
-           
+
             Bundle buyIntentBundle = serviceConnection.Service.GetBuyIntent(3, Context.PackageName, productSku, itemType, payload);
             var response = GetResponseCodeFromBundle(buyIntentBundle);
 
-            
-            switch(response)
+
+            switch (response)
             {
                 case 0:
                     //OK to purchase
                     break;
                 case 1:
                     //User Cancelled, should try again
-                    throw new InAppBillingPurchaseException(PurchaseError.UserCancelled); 
+                    throw new InAppBillingPurchaseException(PurchaseError.UserCancelled);
                 case 3:
                     //Billing Unavailable
                     throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable);
@@ -324,7 +325,7 @@ namespace Plugin.InAppBilling
             {
                 var purchases = await GetPurchasesAsync(itemType, verifyPurchase);
 
-                var purchase = purchases.FirstOrDefault(p => p.ProductId == productSku && p.DeveloperPayload == payload);
+                var purchase = purchases.FirstOrDefault(p => p.ProductId == productSku && payload.Equals(p.DeveloperPayload ?? string.Empty));
 
                 return purchase;
             }
@@ -333,7 +334,7 @@ namespace Plugin.InAppBilling
             if (verifyPurchase == null || await verifyPurchase.VerifyPurchase(data, sign))
             {
                 var purchase = JsonConvert.DeserializeObject<Purchase>(data);
-                if (purchase.ProductId == productSku && purchase.DeveloperPayload == payload)
+                if (purchase.ProductId == productSku && payload.Equals(purchase.DeveloperPayload ?? string.Empty))
                     return purchase;
             }
 
@@ -366,7 +367,7 @@ namespace Plugin.InAppBilling
                 serviceConnection.Dispose();
                 serviceConnection = null;
             }
-            catch(System.Exception ex)
+            catch (System.Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Unable to disconned: {ex.Message}");
             }
@@ -448,7 +449,7 @@ namespace Plugin.InAppBilling
 
             var purchase = purchases.FirstOrDefault(p => p.ProductId == productId && p.Payload == payload);
 
-            if(purchase == null)
+            if (purchase == null)
             {
                 Console.WriteLine("Unable to find a purchase with matching product id and payload");
                 return null;
@@ -495,7 +496,7 @@ namespace Plugin.InAppBilling
             {
                 tcsPurchase?.TrySetResult(null);
             }
-            
+
         }
 
         [Preserve(AllMembers = true)]
@@ -508,7 +509,7 @@ namespace Plugin.InAppBilling
 
         InAppBillingServiceConnection serviceConnection;
         static TaskCompletionSource<PurchaseResponse> tcsPurchase;
-        
+
         static bool ValidOwnedItems(Bundle purchased)
         {
             return purchased.ContainsKey(RESPONSE_IAP_PURCHASE_ITEM_LIST)
@@ -540,7 +541,7 @@ namespace Plugin.InAppBilling
             }
 
             TaskCompletionSource<bool> tcsConnect;
-           
+
             public Context Context { get; private set; }
             public IInAppBillingService Service { get; private set; }
             public bool IsConnected { get; private set; }
@@ -571,8 +572,8 @@ namespace Plugin.InAppBilling
             public Task DisconnectAsync()
             {
                 if (!IsConnected)
-                    return Task.CompletedTask;
-                
+                    return Task.C                ompletedTask;
+
                 Context.UnbindService(this);
 
                 IsConnected = false;
@@ -598,7 +599,7 @@ namespace Plugin.InAppBilling
 
             public void OnServiceDisconnected(ComponentName name)
             {
-               
+
             }
         }
         [Preserve(AllMembers = true)]
@@ -625,11 +626,11 @@ namespace Plugin.InAppBilling
             [JsonProperty(PropertyName = "description")]
             public string Description { get; set; }
 
-            
+
             [JsonProperty(PropertyName = "productId")]
             public string ProductId { get; set; }
 
-            [JsonProperty(PropertyName ="price_currency_code")]
+            [JsonProperty(ropertyName = "price_currency_code")]
             public string CurrencyCode { get; set; }
 
             [JsonProperty(PropertyName = "price_amount_micros")]
@@ -654,14 +655,14 @@ namespace Plugin.InAppBilling
             [JsonProperty(PropertyName = "autoRenewing")]
             public bool AutoRenewing { get; set; }
 
-            [JsonProperty(PropertyName="packageName")]
+            [JsonPropert=ropertyName = "packageName")]
             public string PackageName { get; set; }
 
 
             [JsonProperty(PropertyName = "orderId")]
             public string OrderId { get; set; }
 
-            [JsonProperty(PropertyName ="productId")]
+            [JsonProperty(ropertyName = "productId")]
             public string ProductId { get; set; }
 
 
@@ -802,7 +803,7 @@ namespace Plugin.InAppBilling
             /// <returns></returns>
             public static string TransformString(string key, int i)
             {
-                var chars = key.ToCharArray();;
+                var chars = key.oCharArray(); ;
                 for (int j = 0; j < chars.Length; j++)
                     chars[j] = (char)(chars[j] ^ i);
                 return new string(chars);

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -298,7 +298,7 @@ namespace Plugin.InAppBilling
                 case 7:
                     var purchases = await GetPurchasesAsync(itemType, verifyPurchase);
 
-                    var purchase = purchases.FirstOrDefault(p => p.ProductId == productSku && p.DeveloperPayload == payload);
+                    var purchase = purchases.FirstOrDefault(p => p.ProductId == productSku && payload.Equals(p.DeveloperPayload ?? string.Empty));
 
                     return purchase;
                     //already purchased

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -315,8 +315,6 @@ namespace Plugin.InAppBilling
             if (result == null)
                 return null;
 
-
-
             var data = result.PurchaseData;
             var sign = result.DataSignature;
 
@@ -329,7 +327,6 @@ namespace Plugin.InAppBilling
 
                 return purchase;
             }
-
 
             if (verifyPurchase == null || await verifyPurchase.VerifyPurchase(data, sign))
             {
@@ -572,7 +569,7 @@ namespace Plugin.InAppBilling
             public Task DisconnectAsync()
             {
                 if (!IsConnected)
-                    return Task.C                ompletedTask;
+                    return Task.CompletedTask;
 
                 Context.UnbindService(this);
 
@@ -630,7 +627,7 @@ namespace Plugin.InAppBilling
             [JsonProperty(PropertyName = "productId")]
             public string ProductId { get; set; }
 
-            [JsonProperty(ropertyName = "price_currency_code")]
+            [JsonProperty(PropertyName = "price_currency_code")]
             public string CurrencyCode { get; set; }
 
             [JsonProperty(PropertyName = "price_amount_micros")]
@@ -655,14 +652,14 @@ namespace Plugin.InAppBilling
             [JsonProperty(PropertyName = "autoRenewing")]
             public bool AutoRenewing { get; set; }
 
-            [JsonPropert=ropertyName = "packageName")]
+            [JsonProperty(PropertyName = "packageName")]
             public string PackageName { get; set; }
 
 
             [JsonProperty(PropertyName = "orderId")]
             public string OrderId { get; set; }
 
-            [JsonProperty(ropertyName = "productId")]
+            [JsonProperty(PropertyName = "productId")]
             public string ProductId { get; set; }
 
 
@@ -803,7 +800,7 @@ namespace Plugin.InAppBilling
             /// <returns></returns>
             public static string TransformString(string key, int i)
             {
-                var chars = key.oCharArray(); ;
+                var chars = key.ToCharArray(); ;
                 for (int j = 0; j < chars.Length; j++)
                     chars[j] = (char)(chars[j] ^ i);
                 return new string(chars);


### PR DESCRIPTION
Merged the code from @CrewNerd that prevents a problem with empty payload strings.
From now on all the exceptions are InAppBillingPurchaseException

Fixes #42 

Changes Proposed in this pull request:
- Use typed InAppBillingPurchaseException

Changes from @CrewNerd:
- Promote null payloads to string.Empty to prevent confusion between the two. Empty payload strings get deserialized as null causing it to appear as though the purchase failed.
- Initialize tcsPurchase earlier to prevent a possible race condition.
