### PR TITLE
Added more typed exceptions

### DIFF
--- a/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
+++ b/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
@@ -54,7 +54,11 @@ namespace Plugin.InAppBilling.Abstractions
         /// <summary>
         /// Restoring the transaction failed
         /// </summary>
-        RestoreFailed
+        RestoreFailed,
+        /// <summary>
+        /// Network connection is down
+        /// </summary>
+        ServiceUnavailable
     }
 
     /// <summary>


### PR DESCRIPTION
Add an InAppBillingPurchaseException when the service is unavailable. I've also added a general exception so when we don't know the specific response code we return it in the message of the exception.

Fixes #42 

Changes Proposed in this pull request:
- Added InAppBillingPurchaseException when the service is unavailable
- Throw exception with response code in message when response is not handled
