### PR TITLE
Replaced "BillingUnavailable" with "ServiceUnavailable" for certain cases

### DIFF
--- a/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
+++ b/src/Plugin.InAppBilling.Abstractions/InAppBillingExceptions.cs
@@ -11,10 +11,10 @@ namespace Plugin.InAppBilling.Abstractions
     /// </summary>
     public enum PurchaseError
     {
-        /// <summary>
-        /// Billing system unavailable
-        /// </summary>
-        BillingUnavailable,
+		/// <summary>
+		/// Billing API version is not supported for the type requested (Android), client error (iOS)
+		/// </summary>
+		BillingUnavailable,
         /// <summary>
         /// Developer issue
         /// </summary>

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -81,7 +81,7 @@ namespace Plugin.InAppBilling
         {
             if (serviceConnection?.Service == null)
             {
-                throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
             }
 
             IEnumerable<Product> products = null;
@@ -151,7 +151,7 @@ namespace Plugin.InAppBilling
         {
             if (serviceConnection?.Service == null)
             {
-                throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
             }
 
             List<Purchase> purchases = null;
@@ -252,7 +252,7 @@ namespace Plugin.InAppBilling
 
             if (serviceConnection?.Service == null)
             {
-                throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
             }
 
             Purchase purchase = null;
@@ -403,7 +403,7 @@ namespace Plugin.InAppBilling
         {
             if (serviceConnection?.Service == null)
             {
-                throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
             }
 
             var response = serviceConnection.Service.ConsumePurchase(3, Context.PackageName, purchaseToken);
@@ -466,7 +466,7 @@ namespace Plugin.InAppBilling
         public async override Task<InAppBillingPurchase> ConsumePurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase)
         {
             if (serviceConnection?.Service == null)
-                throw new InAppBillingPurchaseException(PurchaseError.BillingUnavailable, "You are not connected to the Google Play App store.");
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
 
 
             if (payload == null)


### PR DESCRIPTION
Make Android implementation more internally consistent and consistent with Android documentation.

Fixes #118 

Changes Proposed in this pull request:
- When Google Play service connection refused, return ServiceUnavailable instead, as Android documentation shows BillingUnavailable is specific (https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse.html#BILLING_UNAVAILABLE)
- Changed XML comment appropriately for PurchaseError


Should consider changing iOS "SKError.ClientInvalid" to something other than BillingUnavailable, if the reasons for iOS returning that error are substantially different from the reasons on Android.
