### PR TITLE
fix https://github.com/jamesmontemagno/InAppBillingPlugin/issues/111

### DIFF
--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -504,7 +504,18 @@ namespace Plugin.InAppBilling
         public static void HandleActivityResult(int requestCode, Result resultCode, Intent data)
         {
 
-            if (PURCHASE_REQUEST_CODE != requestCode || data == null)
+            if (PURCHASE_REQUEST_CODE != requestCode)
+            {
+                return;
+            }
+
+            if(resultCode == Result.Canceled && tcsPurchase != null && !tcsPurchase.Task.IsCompleted)
+            {
+                tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
+                return;
+            }
+
+            if(data == null)
             {
                 return;
             }


### PR DESCRIPTION
We faced with the same behavior.
A user sends app to background, when payment popup is shown.

I've already investigated a little. So, I think, it can be help to avoid NULL-result all time after canceling payment.

https://github.com/jamesmontemagno/InAppBillingPlugin/issues/111
