### PR TITLE
FIXED: Always call OnPurchaseSuccess if defined for out of band purchases

### DIFF
--- a/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
@@ -446,8 +446,7 @@ namespace Plugin.InAppBilling
 					case SKPaymentTransactionState.Purchased:
 						TransactionCompleted?.Invoke(transaction, true);
 
-						if (TransactionCompleted != null)
-							onPurchaseSuccess?.Invoke(transaction.ToIABPurchase());
+						onPurchaseSuccess?.Invoke(transaction.ToIABPurchase());
 
 						SKPaymentQueue.DefaultQueue.FinishTransaction(transaction);
 						break;


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #176 .

Changes Proposed in this pull request:
- Always call `OnPurchaseSuccess` if defined, allowing this handler to process out of band purchases (such as after changing payment method)

Credit: @kjoiner
