### PR TITLE
Added InAppBilling.VerifyPreviousPurchaseAsync()

### DIFF
--- a/src/Plugin.InAppBilling.Abstractions/BaseInAppBilling.cs
+++ b/src/Plugin.InAppBilling.Abstractions/BaseInAppBilling.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Plugin.InAppBilling.Abstractions
@@ -35,24 +36,48 @@ namespace Plugin.InAppBilling.Abstractions
         public abstract Task<IEnumerable<InAppBillingProduct>> GetProductInfoAsync(ItemType itemType, params string[] productIds);
 
 
-        /// <summary>
-        /// Get all current purhcase for a specifiy product type.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
-        /// <param name="verifyPurchase">Verify purchase implementation</param>
-        /// <returns>The current purchases</returns>
-        public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null);
+		/// <summary>
+		/// Verifies a specific product type and product id. Use e.g. when product is already purchased but verification failed and needs to be called again.
+		/// </summary>
+		/// <param name="itemType">Type of product</param>
+		/// <param name="verifyPurchase">Interface to verify purchase</param>
+		/// <param name="productId">Id of product</param>
+		/// <returns>The current purchases</returns>
+		public async Task<bool> VerifyPreviousPurchaseAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase, string productId)
+		{
+			return (await GetPurchasesAsync(itemType, verifyPurchase, productId))?.Any(p => productId.Equals(p?.ProductId)) ?? false;
+		}
 
-        /// <summary>
-        /// Purchase a specific product or subscription
-        /// </summary>
-        /// <param name="productId">Sku or ID of product</param>
-        /// <param name="itemType">Type of product being requested</param>
-        /// <param name="payload">Developer specific payload</param>
-        /// <param name="verifyPurchase">Verify Purchase implementation</param>
-        /// <returns>Purchase details</returns>
-        /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
-        public abstract Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase = null);
+		/// <summary>
+		/// Get all current purchases for a specific product type. If verification fails for some purchase, it's not contained in the result.
+		/// </summary>
+		/// <param name="itemType">Type of product</param>
+		/// <param name="verifyPurchase">Interface to verify purchase</param>
+		/// <param name="verifyOnlyProductId">If you want to verify a specific purchase, provide its id. Other purchases will be returned without verification.</param>
+		/// <returns>The current purchases</returns>
+		protected abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase, string verifyOnlyProductId);
+
+		/// <summary>
+		/// Get all current purchases for a specific product type. If you use verification and it fails for some purchase, it's not contained in the result.
+		/// </summary>
+		/// <param name="itemType">Type of product</param>
+        /// <param name="verifyPurchase">Verify purchase implementation</param>
+		/// <returns>The current purchases</returns>
+		public async Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null)
+		{
+			return await GetPurchasesAsync(itemType, verifyPurchase, null);
+		}
+
+		/// <summary>
+		/// Purchase a specific product or subscription
+		/// </summary>
+		/// <param name="productId">Sku or ID of product</param>
+		/// <param name="itemType">Type of product being requested</param>
+		/// <param name="payload">Developer specific payload</param>
+		/// <param name="verifyPurchase">Verify Purchase implementation</param>
+		/// <returns>Purchase details</returns>
+		/// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
+		public abstract Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string payload, IInAppBillingVerifyPurchase verifyPurchase = null);
 
         /// <summary>
         /// Consume a purchase with a purchase token.

--- a/src/Plugin.InAppBilling.Abstractions/IInAppBilling.cs
+++ b/src/Plugin.InAppBilling.Abstractions/IInAppBilling.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -36,14 +36,22 @@ namespace Plugin.InAppBilling.Abstractions
         /// <returns>List of products</returns>
         Task<IEnumerable<InAppBillingProduct>> GetProductInfoAsync(ItemType itemType, params string[] productIds);
 
-
-        /// <summary>
-        /// Get all current purhcase for a specifiy product type.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
+		/// <summary>
+		/// Verifies a specific product type and product id. Use e.g. when product is already purchased but verification failed and needs to be called again.
+		/// </summary>
+		/// <param name="itemType">Type of product</param>
+		/// <param name="verifyPurchase">Interface to verify purchase</param>
+		/// <param name="productId">Id of product</param>
+		/// <returns>The current purchases</returns>
+		Task<bool> VerifyPreviousPurchaseAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase, string productId);
+		
+		/// <summary>
+		/// Get all current purchases for a specific product type. If you use verification and it fails for some purchase, it's not contained in the result.
+		/// </summary>
+		/// <param name="itemType">Type of product</param>
         /// <param name="verifyPurchase">Verify purchase implementation</param>
-        /// <returns>The current purchases</returns>
-        Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null);
+		/// <returns>The current purchases</returns>
+		Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null);
 
         /// <summary>
         /// Purchase a specific product or subscription

--- a/src/Plugin.InAppBilling.UWP/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.UWP/InAppBillingImplementation.cs
@@ -70,13 +70,7 @@ namespace Plugin.InAppBilling
             return products;
         }
 
-        /// <summary>
-        /// Get all current purchase for a specific product type.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
-        /// <param name="verifyPurchase">Verify purchase implementation</param>
-        /// <returns>The current purchases</returns>
-        public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null)
+        protected async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase, string verifyOnlyProductId)
         {
             // Get list of product receipts from store or simulator
             var xmlReceipt = await CurrentAppMock.GetAppReceiptAsync(InTestingMode);

--- a/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.iOS/InAppBillingImplementation.cs
@@ -88,14 +88,7 @@ namespace Plugin.InAppBilling
 			return productRequestDelegate.WaitForResponse();
 		}
 
-
-		/// <summary>
-		/// Get all current purchase for a specifiy product type.
-		/// </summary>
-		/// <param name="itemType">Type of product</param>
-		/// <param name="verifyPurchase">Interface to verify purchase</param>
-		/// <returns>The current purchases</returns>
-		public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null)
+		protected async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase, string verifyOnlyProductId)
 		{
 			var purchases = await RestoreAsync();
 
@@ -111,7 +104,7 @@ namespace Plugin.InAppBilling
 			var validPurchases = new List<InAppBillingPurchase>();
 			foreach (var purchase in converted)
 			{
-				if (await ValidateReceipt(verifyPurchase, purchase.ProductId, purchase.Id))
+				if ((verifyOnlyProductId != null && !verifyOnlyProductId.Equals(purchase.ProductId)) || await ValidateReceipt(verifyPurchase, purchase.ProductId, purchase.Id))
 					validPurchases.Add(purchase);
 			}
 


### PR DESCRIPTION
So I was thinking, what should I do if user purchases the product in the store but the verification on our server fails. I was looking for a way to call the verification on this purchase again, but did not find a solution.

Calling `InAppBillingImplementation.GetPurchasesAsync()` with verification will try to verify all the previous purchases, which is not what I want - it will fail on the server because it had been verified before and also the server request will be pointless for those already verified purchases. And if user just tries to purchase the product again, it will fail with `PurchaseError.AlreadyOwned` and the verification will not be performed, right?

I've been thinking about many ways how this could be implemented, but I think this one is the easiest. Tell me what you think, it's my first PR here.

Changes Proposed in this pull request:
- added `BaseInAppBilling.VerifyPreviousPurchaseAsync()` method to support verifying a single previous purchase, internally using `GetPurchasesAsync()` method with verification limited to the specified product
- changed `InAppBillingImplementation.GetPurchasesAsync()` methods to `protected` to support the additional parameter and moved the original `public` method to `BaseInAppBilling`
