### PR TITLE
Fix Issues Surrounding tcsPurchase

### DIFF
--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -365,8 +365,6 @@ namespace Plugin.InAppBilling
         public override Task<bool> ConnectAsync(ItemType itemType = ItemType.InAppPurchase)
         {
             serviceConnection = new InAppBillingServiceConnection(Context, itemType);
-            tcsPurchase?.TrySetCanceled();
-            tcsPurchase = null;
             return serviceConnection.ConnectAsync();
         }
 
@@ -524,38 +522,38 @@ namespace Plugin.InAppBilling
 
             switch (responseCode)
             {
-	            case 0:
-		            //Reponse returned OK
-		            var purchaseData = data.GetStringExtra(RESPONSE_IAP_DATA);
-		            var dataSignature = data.GetStringExtra(RESPONSE_IAP_DATA_SIGNATURE);
+                case 0:
+                    //Reponse returned OK
+                    var purchaseData = data.GetStringExtra(RESPONSE_IAP_DATA);
+                    var dataSignature = data.GetStringExtra(RESPONSE_IAP_DATA_SIGNATURE);
 
-		            tcsPurchase?.TrySetResult(new PurchaseResponse
-		            {
-			            PurchaseData = purchaseData, DataSignature = dataSignature
-		            });
-		            break;
-	            case RESPONSE_CODE_RESULT_USER_CANCELED:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
-		            break;
-	            case RESPONSE_CODE_RESULT_SERVICE_UNAVAILABLE:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable));
-		            break;
-	            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.ItemUnavailable));
-		            break;
-	            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.DeveloperError));
-		            break;
-	            case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.AlreadyOwned));
-		            break;
-	            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.NotOwned));
-		            break;
-	            default:
-		            tcsPurchase?.TrySetException(
-			            new InAppBillingPurchaseException(PurchaseError.GeneralError, responseCode.ToString()));
-		            break;
+                    tcsPurchase?.TrySetResult(new PurchaseResponse
+                    {
+                        PurchaseData = purchaseData,
+                        DataSignature = dataSignature
+                    });
+                    break;
+                case RESPONSE_CODE_RESULT_USER_CANCELED:
+                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
+                    break;
+                case RESPONSE_CODE_RESULT_SERVICE_UNAVAILABLE:
+                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable));
+                    break;
+				case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.ItemUnavailable));
+					break;
+				case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.DeveloperError));
+					break;
+				case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
+					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.AlreadyOwned));
+					break;
+				case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.NotOwned));
+					break;
+				default:
+                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.GeneralError, responseCode.ToString()));
+                    break;
             }
         }
 

--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -365,6 +365,8 @@ namespace Plugin.InAppBilling
         public override Task<bool> ConnectAsync(ItemType itemType = ItemType.InAppPurchase)
         {
             serviceConnection = new InAppBillingServiceConnection(Context, itemType);
+            tcsPurchase?.TrySetCanceled();
+            tcsPurchase = null;
             return serviceConnection.ConnectAsync();
         }
 
@@ -522,38 +524,38 @@ namespace Plugin.InAppBilling
 
             switch (responseCode)
             {
-                case 0:
-                    //Reponse returned OK
-                    var purchaseData = data.GetStringExtra(RESPONSE_IAP_DATA);
-                    var dataSignature = data.GetStringExtra(RESPONSE_IAP_DATA_SIGNATURE);
+	            case 0:
+		            //Reponse returned OK
+		            var purchaseData = data.GetStringExtra(RESPONSE_IAP_DATA);
+		            var dataSignature = data.GetStringExtra(RESPONSE_IAP_DATA_SIGNATURE);
 
-                    tcsPurchase?.TrySetResult(new PurchaseResponse
-                    {
-                        PurchaseData = purchaseData,
-                        DataSignature = dataSignature
-                    });
-                    break;
-                case RESPONSE_CODE_RESULT_USER_CANCELED:
-                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
-                    break;
-                case RESPONSE_CODE_RESULT_SERVICE_UNAVAILABLE:
-                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable));
-                    break;
-				case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
-					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.ItemUnavailable));
-					break;
-				case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
-					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.DeveloperError));
-					break;
-				case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
-					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.AlreadyOwned));
-					break;
-				case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
-					tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.NotOwned));
-					break;
-				default:
-                    tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.GeneralError, responseCode.ToString()));
-                    break;
+		            tcsPurchase?.TrySetResult(new PurchaseResponse
+		            {
+			            PurchaseData = purchaseData, DataSignature = dataSignature
+		            });
+		            break;
+	            case RESPONSE_CODE_RESULT_USER_CANCELED:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
+		            break;
+	            case RESPONSE_CODE_RESULT_SERVICE_UNAVAILABLE:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable));
+		            break;
+	            case BILLING_RESPONSE_RESULT_ITEM_UNAVAILABLE:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.ItemUnavailable));
+		            break;
+	            case BILLING_RESPONSE_RESULT_DEVELOPER_ERROR:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.DeveloperError));
+		            break;
+	            case BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.AlreadyOwned));
+		            break;
+	            case BILLING_RESPONSE_RESULT_ITEM_NOT_OWNED:
+		            tcsPurchase?.TrySetException(new InAppBillingPurchaseException(PurchaseError.NotOwned));
+		            break;
+	            default:
+		            tcsPurchase?.TrySetException(
+			            new InAppBillingPurchaseException(PurchaseError.GeneralError, responseCode.ToString()));
+		            break;
             }
         }
 


### PR DESCRIPTION
This pull request resolves a fixes a few issues surrounding the static field, tcsPurchase in the Android InAppBillingImplementation class.
    
**Changes Proposed in this pull request:**
- HandleActivityResult should use null-conditional access when accessing members of tcsPurchase.
- HandleActivityResult should use TrySetException() rather than SetException() to avoid InvalidOperationException in the case that the task is in a final state.
- Try to cancel and then null the tcsPurchase when ConnectAsync() is invoked. This was done to prevent tcsPurcahse from being stuck in a WaitingForActivation TaskStatus state when the activity is destroyed and recreated while the purchase modal is being presented to the user. This was causing all future purchase attempts to return null when invoking PurchaseAsync(). This is reproducible by turning on "Don't Keep Activities" in Developer Options, invoking PurchaseAsync(), backgrounding the application, and then invoking PurchaseAsync() again once the activity returns to the foreground.