### PR TITLE
InAppBillingPurchase comparer to consider TransactionDateUtc

### DIFF
--- a/src/Plugin.InAppBilling.Abstractions/InAppBillingPurchase.cs
+++ b/src/Plugin.InAppBilling.Abstractions/InAppBillingPurchase.cs
@@ -75,11 +75,11 @@ namespace Plugin.InAppBilling.Abstractions
 			(obj is InAppBillingPurchase purchase) && Equals(purchase);
 
 		public bool Equals(InAppBillingPurchase other) =>
-			(Id, ProductId, AutoRenewing, PurchaseToken, State, Payload) ==
-			(other.Id, other.ProductId, other.AutoRenewing, other.PurchaseToken, other.State, other.Payload);
+			(Id, TransactionDateUtc, ProductId, AutoRenewing, PurchaseToken, State, Payload) ==
+			(other.Id, other.TransactionDateUtc, other.ProductId, other.AutoRenewing, other.PurchaseToken, other.State, other.Payload);
 
 		public override int GetHashCode() =>
-			(Id, ProductId, AutoRenewing, PurchaseToken, State, Payload).GetHashCode();
+			(Id, TransactionDateUtc, ProductId, AutoRenewing, PurchaseToken, State, Payload).GetHashCode();
 
 		/// <summary>
 		/// Prints out product


### PR DESCRIPTION
Fixes #175 .

Changes Proposed in this pull request:

For auto-renew iOS subscriptions there can be multiple receipts. Presently if there is more than one receipt `GetPurchasesAsync` is picking one randomly to return. This is because the `InAppBillingPurchaseComparer` does not take into account `TransactionDateUtc` which is what differentiates these receipts.

This change will return all valid subscription receipts.