### PR TITLE
Fix typo in example

### DIFF
--- a/docs/CheckAndRestorePurchases.md
+++ b/docs/CheckAndRestorePurchases.md
@@ -27,7 +27,7 @@ public async Task<bool> WasItemPurchased(string productId)
         if (!connected)
         {
             //Couldn't connect
-            return;
+            return false;
         }
 
         //check purchases


### PR DESCRIPTION
Example did not compile because a return statement didn't return a value.

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
-
-
- 
