### PR TITLE
Fix returned error code when already owned

### DIFF
--- a/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
+++ b/src/Plugin.InAppBilling.Android/InAppBillingImplementation.cs
@@ -506,16 +506,10 @@ namespace Plugin.InAppBilling
                 return;
             }
 
-            if(resultCode == Result.Canceled && tcsPurchase != null && !tcsPurchase.Task.IsCompleted)
-            {
-                tcsPurchase.SetException(new InAppBillingPurchaseException(PurchaseError.UserCancelled));
-                return;
-            }
-
-            if(data == null)
-            {
-                return;
-            }
+			if (data == null)
+			{
+				return;
+			}
 
             int responseCode = data.GetIntExtra(RESPONSE_CODE, 0);
 


### PR DESCRIPTION
Fixes #236 

Changes Proposed in this pull request:
- Removes a check that occurs too early and prevents all the other checks from happening
- Fixes the error code returned when already owned
- 
