### PR TITLE
Update TestingAndTroubleshooting.md

### DIFF
--- a/docs/TestingAndTroubleshooting.md
+++ b/docs/TestingAndTroubleshooting.md
@@ -18,6 +18,7 @@ You will not be able to test any StoreKit functionality until you have an iOS Pa
 * Just open the app you're trying to test
 * Your app will prompt you to sign in
 * Enter your credentials for your sandbox test account
+* While you could e.g. read your items, you need a real device to test purchasing. Purchasing does not work on Simulators.
 
 
 ## Android Testing 


### PR DESCRIPTION
Clarify that purchasing does not work on iOS Simulators

In Android section, first info is that you MUST use a real device. In iOS, most things work with simulators, but purchasing is not supported. I always get "Cannot connect to iTunes Store" so it might also help others to add this info to the iOS part.