### PR TITLE
Update TestingAndTroubleshooting.md

### DIFF
--- a/docs/TestingAndTroubleshooting.md
+++ b/docs/TestingAndTroubleshooting.md
@@ -36,6 +36,7 @@ You will not be able to test any StoreKit functionality until you have an iOS Pa
 <AndroidSigningKeyAlias>ALIAS</AndroidSigningKeyAlias>
 <AndroidSigningKeyPass>PASS</AndroidSigningKeyPass>
 ```
+* You could use the static product IDs for testing, e.g. android.test.purchased, as described in [Androids Developer Documentation](https://developer.android.com/google/play/billing/billing_testing).
 
 ## Android Troubleshooing
 * If you see "You need to sign into your google account". This most likely means that you don't have an items published and active for IAB


### PR DESCRIPTION
Added link to Androids Developer Documentation for testing with reserved product ids like android.test.purchased. Might be helpful for testing.