### PR TITLE
fix(): added info to match migration to version 4

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -104,6 +104,7 @@ protected override void OnActivityResult(int requestCode, Result resultCode, Int
 ```
 
 ## Android Current Activity Setup
+> This only applies if you use a Version lower than 4
 
 This plugin uses the [Current Activity Plugin](https://github.com/jamesmontemagno/CurrentActivityPlugin/blob/master/README.md) to get access to the current Android Activity. Be sure to complete the full setup if a MainApplication.cs file was not automatically added to your application. Please fully read through the [Current Activity Plugin Documentation](https://github.com/jamesmontemagno/CurrentActivityPlugin/blob/master/README.md). At an absolute minimum you must set the following in your Activity's OnCreate method:
 


### PR DESCRIPTION
The main readme.md says [here](https://github.com/nebula2/InAppBillingPlugin/blob/master/README.md#upgrading-from-23-to-4) that you need to remove 
```csharp
Plugin.CurrentActivity.CrossCurrentActivity.Current.Activity = this;
```
To make it clear I added a little hint.