### PR TITLE
[iOS] Handle Apple NSUnderlyingError instead of failing on GeneralError when Terms & Conditions have changed

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -254,7 +254,9 @@ namespace Plugin.InAppBilling
 				var errorCode = tran?.Error?.Code ?? -1;
 				var description = tran?.Error?.LocalizedDescription ?? string.Empty;
 				var error = PurchaseError.GeneralError;
-				switch (errorCode)
+                var underlyingError = tran?.Error?.UserInfo?["NSUnderlyingError"] as NSError;
+
+                switch (errorCode)
 				{
 					case (int)SKError.PaymentCancelled:
 						error = PurchaseError.UserCancelled;
@@ -269,7 +271,7 @@ namespace Plugin.InAppBilling
 						error = PurchaseError.ItemUnavailable;
 						break;
 					case (int)SKError.Unknown:
-						error = PurchaseError.GeneralError;
+						error = underlyingError?.Code == 3038 ? PurchaseError.AppleTermsConditionsChanged : PurchaseError.GeneralError;
 						break;
 					case (int)SKError.ClientInvalid:
 						error = PurchaseError.BillingUnavailable;

--- a/src/Plugin.InAppBilling/Shared/InAppBillingExceptions.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/InAppBillingExceptions.shared.cs
@@ -69,7 +69,8 @@ namespace Plugin.InAppBilling
 		NotOwned,
         FeatureNotSupported,
         ServiceDisconnected,
-        ServiceTimeout
+        ServiceTimeout,
+        AppleTermsConditionsChanged
 	}
 
     /// <summary>


### PR DESCRIPTION
**For iOS only: Handle Apple NSUnderlyingError instead of failing on GeneralError when Terms & Conditions have changed**

This message is shown when you enable 'interrupt purchases' in the Sandbox users on App Store Connect. When placing the purchase, PurchaseAsync is called and it returns a GeneralError. What actually is happening is Apple is refusing the payment to be made until the user accepts the updated Terms of Service.

![image](https://user-images.githubusercontent.com/16294492/117267331-751a2400-ae56-11eb-9a96-3ca36dfcee70.png)

To reproduce, please visit App Store Connect and navigate to the 'Users and Access' section. In the side menu, click Testers under Sandbox. Click or create a user and tick the box 'Interrupt purchases'. Log in and out of your Sandbox account from the iOS device and try to make a purchase. After pressing the blue 'Buy' button you will get this popup.

![image](https://user-images.githubusercontent.com/16294492/117267706-d8a45180-ae56-11eb-85d4-79d67d96abef.png)

Fixes issue where the plugin returned invalid status for the payment. An app I submitted was denied for having shown an error message for this.

Changes Proposed in this pull request:
- In case of SKError.Unknown, check for underlying NSError and check this with number 3038. There does not seem to be a constant within the Apple SDK for this. I found this by debugging and a thread on Apple's forums

Please tell me if I can make any corrections to my change or other ways of handling this are known.

A report on Apple forums: https://developer.apple.com/forums/thread/674081
