### PR TITLE
Reinstate IInAppBillingVerifyPurchase parameter to GetPurchasesAsync()

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -98,15 +98,20 @@ namespace Plugin.InAppBilling
 			return productRequestDelegate.WaitForResponse();
 		}
 
-		public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType)
+		public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null)
 		{
 			var purchases = await RestoreAsync();
 
 			var comparer = new InAppBillingPurchaseComparer();
-			return purchases
+			var converted = purchases
 				?.Where(p => p != null)
 				?.Select(p2 => p2.ToIABPurchase())
 				?.Distinct(comparer);
+
+			//try to validate purchases
+			var validated = await ValidateReceipt(verifyPurchase, string.Empty, string.Empty);
+
+			return validated ? converted : null;
 		}
 
 

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -43,7 +43,7 @@ namespace Plugin.InAppBilling
 		/// </summary>
 		/// <param name="itemType">Type of product</param>
 		/// <returns>The current purchases</returns>
-		public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType);
+		public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null);
 
         /// <summary>
         /// Purchase a specific product or subscription

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -45,7 +45,7 @@ namespace Plugin.InAppBilling
 		/// <param name="itemType">Type of product</param>
         /// <param name="verifyPurchase">Verify purchase implementation</param>
 		/// <returns>The current purchases</returns>
-		Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType);
+		Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, IInAppBillingVerifyPurchase verifyPurchase = null);
 
         /// <summary>
         /// Purchase a specific product or subscription


### PR DESCRIPTION
Changes Proposed in this pull request:
Reinstates the IInAppBillingVerifyPurchase parameter to GetPurchasesAsync() (was in v2 nuget but removed in v4). This allows purchases (especially subscriptions) to be restored securely, even if historic backend records are unavailable. The default value is null (as per previous implementation), making this a non-breaking change. The new implementations for Apple and Android are similar to the original implementation, but adapted for the v4 changes.

@jamesmontemagno Many thanks for the awesome library and apologies if I have missed anything or broken protocol in some way - this is my first PR to someone else's project! 🙏