### PR TITLE
Fixes #402 null ref awaiting ConsumePurchaseAsync

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -324,7 +324,7 @@ namespace Plugin.InAppBilling
 		/// <returns>If consumed successful</returns>
 		/// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
 		public override Task<bool> ConsumePurchaseAsync(string productId, string purchaseToken) =>
-			null;
+			Task.FromResult(true);
 
 	
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #402

Changes Proposed in this pull request:

Instead of returning `null` and forcing the consumer to make a platform check, to see if they need to omit calling this method. Instead, just always return true, as consumable IAP on iOS are consumed immediately after a purchase.