### PR TITLE
Android subscriptions downgrade / upgrade (Google Play Billing Library 4.0.0 c…

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -200,6 +200,99 @@ namespace Plugin.InAppBilling
         }
 
         /// <summary>
+        /// (Android specific) Upgrade/Downgrade/Change a previously purchased subscription
+        /// </summary>
+        /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
+        /// <param name="oldProductId">Sku or ID of product that needs to be upgraded</param>
+        /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription</param>
+        /// <param name="prorationMode">Proration mode (1 - ImmediateWithTimeProration, 2 - ImmediateAndChargeProratedPrice, 3 - ImmediateWithoutProration, 4 - Deferred)</param>
+        /// <param name="verifyPurchase">Verify Purchase implementation</param>
+        /// <returns>Purchase details</returns>
+        public override async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
+        {
+            if (BillingClient == null || !IsConnected)
+            {
+                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
+            }
+
+            // If we have a current task and it is not completed then return null.
+            // you can't try to purchase twice.
+            if (tcsPurchase?.Task != null && !tcsPurchase.Task.IsCompleted)
+            {
+                return null;
+            }
+
+            var purchase = await UpgradePurchasedSubscriptionInternalAsync(newProductId, purchaseTokenOfOriginalSubscription, prorationMode, verifyPurchase);
+
+            return purchase;
+        }
+
+        async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionInternalAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
+        {
+            var itemType = BillingClient.SkuType.Subs;
+
+            if (tcsPurchase?.Task != null && !tcsPurchase.Task.IsCompleted)
+            {
+                return null;
+            }
+
+            var skuDetailsParams = SkuDetailsParams.NewBuilder()
+                .SetType(itemType)
+                .SetSkusList(new List<string> { newProductId })
+                .Build();
+
+            var skuDetailsResult = await BillingClient.QuerySkuDetailsAsync(skuDetailsParams);
+            ParseBillingResult(skuDetailsResult?.Result);
+
+            var skuDetails = skuDetailsResult?.SkuDetails.FirstOrDefault();
+
+            if (skuDetails == null)
+                throw new ArgumentException($"{newProductId} does not exist");
+
+            //1 - BillingFlowParams.ProrationMode.ImmediateWithTimeProration
+            //2 - BillingFlowParams.ProrationMode.ImmediateAndChargeProratedPrice
+            //3 - BillingFlowParams.ProrationMode.ImmediateWithoutProration
+            //4 - BillingFlowParams.ProrationMode.Deferred
+
+            var updateParams = BillingFlowParams.SubscriptionUpdateParams.NewBuilder()
+                .SetOldSkuPurchaseToken(purchaseTokenOfOriginalSubscription)
+                .SetReplaceSkusProrationMode(prorationMode)
+                .Build();
+
+            var flowParams = BillingFlowParams.NewBuilder()
+                .SetSkuDetails(skuDetails)
+                .SetSubscriptionUpdateParams(updateParams)
+                .Build();
+
+            tcsPurchase = new TaskCompletionSource<(BillingResult billingResult, IList<Android.BillingClient.Api.Purchase> purchases)>();
+            var responseCode = BillingClient.LaunchBillingFlow(Activity, flowParams);
+
+            ParseBillingResult(responseCode);
+
+            var result = await tcsPurchase.Task;
+            ParseBillingResult(result.billingResult);
+
+            //we are only buying 1 thing.
+            var androidPurchase = result.purchases?.FirstOrDefault(p => p.Skus.Contains(newProductId));
+
+            //for some reason the data didn't come back
+            if (androidPurchase == null)
+            {
+                var purchases = await GetPurchasesAsync(itemType == BillingClient.SkuType.Inapp ? ItemType.InAppPurchase : ItemType.Subscription);
+                return purchases.FirstOrDefault(p => p.ProductId == newProductId);
+            }
+
+            var data = androidPurchase.OriginalJson;
+            var signature = androidPurchase.Signature;
+
+            var purchase = androidPurchase.ToIABPurchase();
+            if (verifyPurchase == null || await verifyPurchase.VerifyPurchase(data, signature, newProductId, purchase.Id))
+                return purchase;
+
+            return null;
+        }
+
+        /// <summary>
         /// Purchase a specific product or subscription
         /// </summary>
         /// <param name="productId">Sku or ID of product</param>

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -205,6 +205,16 @@ namespace Plugin.InAppBilling
             return purchase;
 		}
 
+        /// <summary>
+        /// (iOS not supported) Apple store manages upgrades natively when subscriptions of the same group are purchased.
+        /// </summary>
+        /// <exception cref="NotImplementedException">iOS not supported</exception>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
+        {
+            throw new NotImplementedException("iOS not supported. Apple store manages upgrades natively when subscriptions of the same group are purchased.");
+        }
+
+
         public override string ReceiptData
         {
             get

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -209,10 +209,8 @@ namespace Plugin.InAppBilling
         /// (iOS not supported) Apple store manages upgrades natively when subscriptions of the same group are purchased.
         /// </summary>
         /// <exception cref="NotImplementedException">iOS not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
-        {
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration) =>
             throw new NotImplementedException("iOS not supported. Apple store manages upgrades natively when subscriptions of the same group are purchased.");
-        }
 
 
         public override string ReceiptData

--- a/src/Plugin.InAppBilling/InAppBilling.uwp.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.uwp.cs
@@ -96,6 +96,15 @@ namespace Plugin.InAppBilling
         }
 
         /// <summary>
+        /// (UWP not supported) Upgrade/Downgrade/Change a previously purchased subscription
+        /// </summary>
+        /// <exception cref="NotImplementedException">UWP not supported</exception>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
+        {
+            throw new NotImplementedException("UWP not supported.");
+        }
+
+        /// <summary>
         /// Consume a purchase with a purchase token.
         /// </summary>
         /// <param name="productId">Id or Sku of product</param>

--- a/src/Plugin.InAppBilling/InAppBilling.uwp.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.uwp.cs
@@ -99,10 +99,8 @@ namespace Plugin.InAppBilling
         /// (UWP not supported) Upgrade/Downgrade/Change a previously purchased subscription
         /// </summary>
         /// <exception cref="NotImplementedException">UWP not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null)
-        {
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration) =>
             throw new NotImplementedException("UWP not supported.");
-        }
 
         /// <summary>
         /// Consume a purchase with a purchase token.

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -61,6 +61,16 @@ namespace Plugin.InAppBilling
         public abstract Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null);
 
         /// <summary>
+        /// (Android specific) Upgrade/Downgrade a previously purchased subscription
+        /// </summary>
+        /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
+        /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription (can not be null)</param>
+        /// <param name="prorationMode">Proration mode</param>
+        /// <param name="verifyPurchase">Verify Purchase implementation</param>
+        /// <returns>Purchase details</returns>
+        public abstract Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null);
+
+        /// <summary>
         /// Consume a purchase with a purchase token.
         /// </summary>
         /// <param name="productId">Id or Sku of product</param>

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -66,9 +66,8 @@ namespace Plugin.InAppBilling
         /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
         /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription (can not be null)</param>
         /// <param name="prorationMode">Proration mode</param>
-        /// <param name="verifyPurchase">Verify Purchase implementation</param>
         /// <returns>Purchase details</returns>
-        public abstract Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null);
+        public abstract Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration);
 
         /// <summary>
         /// Consume a purchase with a purchase token.

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -63,6 +63,17 @@ namespace Plugin.InAppBilling
         Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null);
 
         /// <summary>
+        /// (Android specific) Upgrade/Downgrade a previously purchased subscription
+        /// </summary>
+        /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
+        /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription (can not be null)</param>
+        /// <param name="prorationMode">Proration mode (1 - ImmediateWithTimeProration, 2 - ImmediateAndChargeProratedPrice, 3 - ImmediateWithoutProration, 4 - Deferred)</param>
+        /// <param name="verifyPurchase">Verify Purchase implementation</param>
+        /// <returns>Purchase details</returns>
+        /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
+        Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null);
+
+        /// <summary>
         /// Consume a purchase with a purchase token.
         /// </summary>
         /// <param name="productId">Id or Sku of product</param>

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -71,7 +71,7 @@ namespace Plugin.InAppBilling
         /// <param name="verifyPurchase">Verify Purchase implementation</param>
         /// <returns>Purchase details</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
-        Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, int prorationMode = 1, IInAppBillingVerifyPurchase verifyPurchase = null);
+        Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration);
 
         /// <summary>
         /// Consume a purchase with a purchase token.

--- a/src/Plugin.InAppBilling/Shared/ItemType.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/ItemType.shared.cs
@@ -20,4 +20,15 @@ namespace Plugin.InAppBilling
         /// </summary>
         Subscription
     }
+
+    /// <summary>
+    /// Subcription proration mode
+    /// </summary>
+    public enum SubscriptionProrationMode
+    {
+        ImmediateWithTimeProration = 1,
+        ImmediateAndChargeProratedPrice = 2,
+        ImmediateWithoutProration = 3,
+        Deferred = 4
+    }
 }


### PR DESCRIPTION
Fixes #26

Changes Proposed in this pull request:

New UpgradePurchasedSubscriptionAsync function is implemented for Android. It uses similar interface as #192 but implementation works fine with latest api (Google Play Billing Library 4.0.0). Implementation for iOS is not necessary, because iOS support upgrades/downgrades itself. I didn't check UWP.