### PR TITLE
Fixed deprecated warning from SKPayment.CreateFrom(string) (Issue #432)

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -289,11 +289,6 @@ namespace Plugin.InAppBilling
 
 			paymentObserver.TransactionCompleted += handler;
 
-#if __IOS__ || __TVOS__
-			
-			var payment = SKPayment.CreateFrom(productId);
-#else
-
 			var products = await GetProductAsync(new[] { productId });
 			var product = products?.FirstOrDefault();
 			if (product == null)
@@ -301,7 +296,7 @@ namespace Plugin.InAppBilling
 
 			var payment = SKPayment.CreateFrom(product);
 			//var payment = SKPayment.CreateFrom((SKProduct)SKProduct.FromObject(new NSString(productId)));
-#endif
+			
 			SKPaymentQueue.DefaultQueue.AddPayment(payment);
 
 			return await tcsTransaction.Task;


### PR DESCRIPTION
Changes Proposed in this pull request:
- Deleted compilation `if` checking for iOS and TVOS platforms when calling `PurchaseAsync(string)`
- Because of that, there's no more call to `SKPayment.CreateFrom(string)` because it's deprecated from iOS 5
