### PR TITLE
Don't auto finish transactions

### DIFF
--- a/docs/CheckAndRestorePurchases.md
+++ b/docs/CheckAndRestorePurchases.md
@@ -12,7 +12,10 @@ Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType);
 
 When you make a call to restore a purchase it will prompt for the user to sign in if they haven't yet, so take that into consideration.
 
-Note, that on iOS this will only return your non-consumables, consumables are not tracked at all and your app should handle these situations
+Note, that on iOS this will only return your non-consumables, consumables that have already been `finished` are not tracked at all and your app should handle these situations.
+
+On iOS, we auto finish all transactions when you get purchases. If you have any consumables you should pass in a `List<string>` with ids that you do not want finished.
+
 
 Example:
 ```csharp
@@ -30,12 +33,15 @@ public async Task<bool> WasItemPurchased(string productId)
         }
 
         //check purchases
-        var purchases = await billing.GetPurchasesAsync(ItemType.InAppPurchase);
+        var idsToNotFinish = new List<string>(new [] {"myconsumable"});
+
+        var purchases = await billing.GetPurchasesAsync(ItemType.InAppPurchase, idsToNotFinish);
 
         //check for null just incase
         if(purchases?.Any(p => p.ProductId == productId) ?? false)
         {
             //Purchase restored
+            // if on Android may be good to 
             return true;
         }
         else
@@ -64,7 +70,7 @@ public async Task<bool> WasItemPurchased(string productId)
 
 ## Subscriptions
 
-On `Android` only valid on-going subscriptions will be returned. `iOS` returns all receipts for all instances of the subscripitions. Read the iOS documentation to learn more on strategies.
+On `Android` only valid on-going subscriptions will be returned (with the original purchase date). `iOS` returns all receipts for all instances of the subscripitions. Read the iOS documentation to learn more on strategies.
 
 Learn more about `IInAppBillingVerifyPurchase` in the [Securing Purchases](SecuringPurchases.md) documentation.
 

--- a/docs/GetProductDetails.md
+++ b/docs/GetProductDetails.md
@@ -11,14 +11,11 @@ After creating the in-app purchase items in the respective app store you can the
 /// <returns>List of products</returns>
 Task<IEnumerable<InAppBillingProduct>> GetProductInfoAsync(ItemType itemType, params string[] productIds);
 ```
-Note that you have to specify an `ItemType` for each call. This means you have to query your `InAppPurchase` and `Subscriptio`n items in multiple calls to the API. Additionally, the `productIds` must be specified in the app, there is no way to query the In-App Billing service to just say "give me everything".
+Note that you have to specify an `ItemType` for each call. This means you have to query your `InAppPurchase` and `Subscription` items in multiple calls to the API. Additionally, the `productIds` must be specified in the app, there is no way to query the In-App Billing service to just say "give me everything".
 
- You will receive back a list of your products that you specified the `productIds` for with the following information:
+ You will receive back a list of your products that you specified the `productIds` for with common information including:
 
  ```csharp
-/// <summary>
-/// Product being offered
-/// </summary>
 public class InAppBillingProduct
 {
     /// <summary>
@@ -30,6 +27,7 @@ public class InAppBillingProduct
     /// Description of the product
     /// </summary>
     public string Description { get; set; }
+
 
     /// <summary>
     /// Product ID or sku
@@ -52,9 +50,24 @@ public class InAppBillingProduct
     /// This value represents the localized, rounded price for a particular currency.
     /// </summary>
     public Int64 MicrosPrice { get; set; }
+
+    /// <summary>
+    /// Extra information for apple platforms
+    /// </summary>
+    public InAppBillingProductAppleExtras AppleExtras { get; set; } = null;
+    /// <summary>
+    /// Extra information for Android platforms
+    /// </summary>
+    public InAppBillingProductAndroidExtras AndroidExtras { get; set; } = null;
+    /// <summary>
+    /// Extra information for Windows platforms
+    /// </summary>
+    public InAppBillingProductWindowsExtras WindowsExtras { get; set; } = null;
+
 }
- ```
+```
  
+This information should be enough for most users, however there are all sorts of special things that each platforms return. That is why there are `AppleExtras`, `AndroidExtras`, and `WindowsExtras`. Each of these return special properties for things like discounts, sales, introductory offers, and subscription group information.
 
 Example:
 ```csharp

--- a/docs/PurchaseNonConsumable.md
+++ b/docs/PurchaseNonConsumable.md
@@ -25,7 +25,7 @@ On Android you must call `AcknowledgePurchaseAsync` within 3 days when a purchas
 
 Example:
 ```csharp
-public async Task<bool> PurchaseItem(string productId, string payload)
+public async Task<bool> PurchaseItem(string productId)
 {
     var billing = CrossInAppBilling.Current;
     try

--- a/docs/PurchaseSubscription.md
+++ b/docs/PurchaseSubscription.md
@@ -49,7 +49,7 @@ public async Task<bool> PurchaseItem(string productId, string payload)
         }
         else
         {
-            //purchased!
+             //purchased!
              if(Device.RuntimePlatform == Device.Android)
              {
                 // Must call AcknowledgePurchaseAsync else the purchase will be refunded

--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -170,7 +170,7 @@ namespace Plugin.InAppBilling
         }
 
         
-		public override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType)
+		public override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, List<string> doNotFinishTransactionIds = null)
         {
             if (BillingClient == null)
                 throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");

--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -147,6 +147,7 @@ namespace Plugin.InAppBilling
             var skuType = itemType switch
             {
                 ItemType.InAppPurchase => BillingClient.SkuType.Inapp,
+                ItemType.InAppPurchaseConsumable => BillingClient.SkuType.Inapp,
                 _ => BillingClient.SkuType.Subs
             };
 
@@ -177,6 +178,7 @@ namespace Plugin.InAppBilling
             var skuType = itemType switch
             {
                 ItemType.InAppPurchase => BillingClient.SkuType.Inapp,
+                ItemType.InAppPurchaseConsumable => BillingClient.SkuType.Inapp,
                 _ => BillingClient.SkuType.Subs
             };
 
@@ -200,6 +202,7 @@ namespace Plugin.InAppBilling
             var skuType = itemType switch
             {
                 ItemType.InAppPurchase => BillingClient.SkuType.Inapp,
+                ItemType.InAppPurchaseConsumable => BillingClient.SkuType.Inapp,
                 _ => BillingClient.SkuType.Subs
             };
 
@@ -318,6 +321,7 @@ namespace Plugin.InAppBilling
             switch (itemType)
             {
                 case ItemType.InAppPurchase:
+                case ItemType.InAppPurchaseConsumable:
                     return await PurchaseAsync(productId, BillingClient.SkuType.Inapp, obfuscatedAccountId, obfuscatedProfileId);
                 case ItemType.Subscription:
 

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -18,7 +18,7 @@ namespace Plugin.InAppBilling
         /// Fall back to 4.0 functionality of always finishing transactions.
         /// This is fine if you have only subscriptions and non-consumables.
         /// </summary>
-		public static bool AutoFinishTransactionsOnRestore { get; set; }
+		public static bool AutoFinishTransactionsOnRestore { get; set; } = true;
 #if __IOS__ || __TVOS__
         internal static bool HasIntroductoryOffer => UIKit.UIDevice.CurrentDevice.CheckSystemVersion(11, 2);
         internal static bool HasProductDiscounts => UIKit.UIDevice.CurrentDevice.CheckSystemVersion(12, 2);

--- a/src/Plugin.InAppBilling/InAppBilling.uwp.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.uwp.cs
@@ -75,8 +75,9 @@ namespace Plugin.InAppBilling
         /// Get all pruchases
         /// </summary>
         /// <param name="itemType"></param>
+        /// <param name="doNotFinishTransactionIds"></param>
         /// <returns></returns>
-        public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType)
+        public async override Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, List<string> doNotFinishTransactionIds = null)
         {
             // Get list of product receipts from store or simulator
             var xmlReceipt = await CurrentAppMock.GetAppReceiptAsync(InTestingMode);

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -143,9 +143,9 @@ namespace Plugin.InAppBilling
         /// <summary>
         /// manually finish a transaction
         /// </summary>
-        /// <param name="purchaseId"></param>
+        /// <param name="purchaseToken"></param>
         /// <returns></returns>
-		public virtual Task<bool> FinishTransaction(string purchaseId) => Task.FromResult(true);
+		public virtual Task<bool> FinishTransaction(string purchaseToken) => Task.FromResult(true);
 
         /// <summary>
         /// acknowledge a purchase

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -56,8 +56,9 @@ namespace Plugin.InAppBilling
 		/// Get all current purchases for a specific product type. If verification fails for some purchase, it's not contained in the result.
 		/// </summary>
 		/// <param name="itemType">Type of product</param>
+        /// <param name="doNotFinishTransactionIds">List of ids not to finish (iOS only)</param>
 		/// <returns>The current purchases</returns>
-		public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType);
+		public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, List<string> doNotFinishTransactionIds = null);
 
 
 

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -52,8 +52,9 @@ namespace Plugin.InAppBilling
 		/// Get all current purchases for a specific product type. If you use verification and it fails for some purchase, it's not contained in the result.
 		/// </summary>
 		/// <param name="itemType">Type of product</param>
+        /// <param name="doNotFinishTransactionIds"></param>
 		/// <returns>The current purchases</returns>
-		Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType);
+		Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, List<string> doNotFinishTransactionIds = null);
 
 
         /// <summary>

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -68,8 +68,8 @@ namespace Plugin.InAppBilling
         /// </summary>
         /// <param name="productId">Sku or ID of product</param>
         /// <param name="itemType">Type of product being requested</param>
-        /// <param name="obfuscatedAccountId">Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.</param>
-        /// <param name="obfuscatedProfileId">Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.</param>
+        /// <param name="obfuscatedAccountId">Android: Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.</param>
+        /// <param name="obfuscatedProfileId">Android: Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.</param>
         /// <returns>Purchase details</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occures during processing</exception>
         Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null);

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -103,9 +103,9 @@ namespace Plugin.InAppBilling
         /// <summary>
         /// Manually finish a transaction
         /// </summary>
-        /// <param name="purchaseId"></param>
+        /// <param name="purchaseToken"></param>
         /// <returns></returns>
-		Task<bool> FinishTransaction(string purchaseId);
+		Task<bool> FinishTransaction(string purchaseToken);
 
         /// <summary>
         /// Get receipt data on iOS

--- a/src/Plugin.InAppBilling/Shared/InAppBillingProduct.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/InAppBillingProduct.shared.cs
@@ -179,11 +179,11 @@ namespace Plugin.InAppBilling
         /// </summary>
         public InAppBillingProductAppleExtras AppleExtras { get; set; } = null;
         /// <summary>
-        /// Extra infor for Android platforms
+        /// Extra information for Android platforms
         /// </summary>
         public InAppBillingProductAndroidExtras AndroidExtras { get; set; } = null;
         /// <summary>
-        /// Extra infor for Windows platforms
+        /// Extra information for Windows platforms
         /// </summary>
         public InAppBillingProductWindowsExtras WindowsExtras { get; set; } = null;
 

--- a/src/Plugin.InAppBilling/Shared/ItemType.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/ItemType.shared.cs
@@ -16,6 +16,10 @@ namespace Plugin.InAppBilling
         /// </summary>
         InAppPurchase,
         /// <summary>
+        /// Single purchase that needs to be consumed manually
+        /// </summary>
+        InAppPurchaseConsumable,
+        /// <summary>
         /// On going subscription
         /// </summary>
         Subscription


### PR DESCRIPTION
Give ability to turn it on though if we want to for back compat for non-consumeables.

Please take a moment to fill out the following:

Fixes #414.

Changes Proposed in this pull request:
- Add back compat to auto finish ios transactions
- Consume on iOS now calls Finish
- Finish still finishes on iOS, but would need to be called for all of them
