### PR TITLE
Add `net6.0` TFM

### DIFF
--- a/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
@@ -7,13 +7,13 @@ namespace Plugin.InAppBilling
     /// </summary>
     public class CrossInAppBilling
     {
-        static Lazy<IInAppBilling> implementation = new Lazy<IInAppBilling>(() => CreateInAppBilling(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
+        static Lazy<IInAppBilling> implementation = new(() => CreateInAppBilling(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
 
 
 		/// <summary>
 		/// Gets if the plugin is supported on the current platform.
 		/// </summary>
-		public static bool IsSupported => implementation.Value == null ? false : true;
+		public static bool IsSupported => implementation.Value != null;
 
 		/// <summary>
 		/// Current plugin implementation to use

--- a/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
@@ -3,7 +3,7 @@
 namespace Plugin.InAppBilling
 {
     /// <summary>
-    /// Cross platform InAppBilling implementations
+    /// Cross platform InAppBilling implemenations
     /// </summary>
     public class CrossInAppBilling
     {

--- a/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/CrossInAppBilling.shared.cs
@@ -3,7 +3,7 @@
 namespace Plugin.InAppBilling
 {
     /// <summary>
-    /// Cross platform InAppBilling implemenations
+    /// Cross platform InAppBilling implementations
     /// </summary>
     public class CrossInAppBilling
     {
@@ -33,7 +33,7 @@ namespace Plugin.InAppBilling
 
         static IInAppBilling CreateInAppBilling()
         {
-#if NETSTANDARD1_0 || NETSTANDARD2_0
+#if NETSTANDARD
             return null;
 #else
 #pragma warning disable IDE0022 // Use expression body for methods

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -107,10 +107,7 @@ namespace Plugin.InAppBilling
 		/// <summary>
 		/// Default constructor for In App Billing on iOS
 		/// </summary>
-		public InAppBillingImplementation()
-		{
-			Init();
-		}
+        public InAppBillingImplementation() => Init();
 
 		void Init()
 		{

--- a/src/Plugin.InAppBilling/InAppBilling.uwp.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.uwp.cs
@@ -212,22 +212,13 @@ namespace Plugin.InAppBilling
                 purchase.ProductIds = new string[] { purchase.ProductId };
 
                 // Map native UWP status to PurchaseState
-                switch (status)
+                purchase.State = status switch
                 {
-                    case ProductPurchaseStatus.AlreadyPurchased:
-                    case ProductPurchaseStatus.Succeeded:
-                        purchase.State = PurchaseState.Purchased;
-                        break;
-                    case ProductPurchaseStatus.NotFulfilled:
-                        purchase.State = PurchaseState.Deferred;
-                        break;
-                    case ProductPurchaseStatus.NotPurchased:
-                        purchase.State = PurchaseState.Canceled;
-                        break;
-                    default:
-                        purchase.State = PurchaseState.Unknown;
-                        break;
-                }
+                    ProductPurchaseStatus.AlreadyPurchased or ProductPurchaseStatus.Succeeded => PurchaseState.Purchased,
+                    ProductPurchaseStatus.NotFulfilled => PurchaseState.Deferred,
+                    ProductPurchaseStatus.NotPurchased => PurchaseState.Canceled,
+                    _ => PurchaseState.Unknown,
+                };
 
                 // Add to list of purchases
                 purchases.Add(purchase);

--- a/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
+++ b/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>Plugin.InAppBilling</AssemblyName>
@@ -87,6 +87,14 @@
 		</ItemGroup>
 	</Target>-->
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <Compile Include="**\*.netstandard.cs" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+  
   <PropertyGroup Condition=" $(TargetFramework.Contains('-android')) ">
     <UseMauiEssentials>true</UseMauiEssentials>
   </PropertyGroup>


### PR DESCRIPTION
Changes Proposed in this pull request:
- Add support for `net6.0` TFM, so that this NuGet could be added to platform-agnostic projects
- Apply some code suggestions from VS
