### PR TITLE
Fix finish order

### DIFF
--- a/src/InAppBillingTests/InAppBillingTests.iOS/AppDelegate.cs
+++ b/src/InAppBillingTests/InAppBillingTests.iOS/AppDelegate.cs
@@ -28,7 +28,8 @@ namespace InAppBillingTests.iOS
 
 			//initialize current one.
 			Plugin.InAppBilling.InAppBillingImplementation.OnShouldAddStorePayment = OnShouldAddStorePayment;
-			var current = Plugin.InAppBilling.CrossInAppBilling.Current;
+            Plugin.InAppBilling.InAppBillingImplementation.ShouldAutomaticallyFinishTransactions = false;
+            var current = Plugin.InAppBilling.CrossInAppBilling.Current;
 
 			return base.FinishedLaunching(app, options);
         }

--- a/src/InAppBillingTests/InAppBillingTests/MainPage.xaml
+++ b/src/InAppBillingTests/InAppBillingTests/MainPage.xaml
@@ -3,10 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:InAppBillingTests"
              xmlns:iap="clr-namespace:Plugin.InAppBilling;assembly=Plugin.InAppBilling"
-             x:Class="InAppBillingTests.MainPage">
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             x:Class="InAppBillingTests.MainPage"
+             ios:Page.UseSafeArea="True">
 
     <StackLayout>
 		<Button Text="Buy Consumable" x:Name="ButtonConsumable" Clicked="ButtonConsumable_Clicked"/>
+        <Button Text="Buy Consumable (broken)" x:Name="ButtonConsumableBroken" Clicked="ButtonConsumable_Clicked" />
+        <Button Text="Finalise broken Consumable" x:Name="FinaliseConsumable" Clicked="FinaliseConsumable_Clicked" />
 		<Button Text="Buy Non-Consumable" x:Name="ButtonNonConsumable" Clicked="ButtonNonConsumable_Clicked"/>
 		<Button Text="Buy Sub" x:Name="ButtonSub" Clicked="ButtonSub_Clicked"/>
         <Button Text="Buy Renewing Sub" x:Name="ButtonRenewingSub" Clicked="ButtonRenewingSub_Clicked"/>

--- a/src/InAppBillingTests/InAppBillingTests/MainPage.xaml.cs
+++ b/src/InAppBillingTests/InAppBillingTests/MainPage.xaml.cs
@@ -1,10 +1,13 @@
 ﻿using Plugin.InAppBilling;
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 
 namespace InAppBillingTests
 {
+
     public partial class MainPage : ContentPage
 	{
         public ObservableCollection<InAppBillingProduct> Items { get; set; } = new ObservableCollection<InAppBillingProduct>();
@@ -13,14 +16,63 @@ namespace InAppBillingTests
 			InitializeComponent();
 		}
 
-		private void ButtonConsumable_Clicked(object sender, EventArgs e)
-		{
+        PurchaseStorage purchaseStorage = new PurchaseStorage();
 
-		}
+        const string consumableProductId = "consumabletest";
+        const string nonConsumableProductId = "iaptest";
 
-		private async void ButtonNonConsumable_Clicked(object sender, EventArgs e)
+        async void ButtonConsumable_Clicked(object sender, EventArgs e)
 		{
-			var id = "iaptest";
+            var shouldSucceed = sender != ButtonConsumableBroken;
+            try
+            {
+                var purchase = await PurchaseProduct(consumableProductId, ItemType.InAppPurchaseConsumable, shouldSucceed);
+
+                if (purchase == null)
+                {
+                    await DisplayAlert(string.Empty, "Did not purchase", "OK");
+                }
+                else
+                {
+                    await DisplayAlert(string.Empty, "We did it!", "OK");
+                }
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert(string.Empty, "Did not purchase: " + ex.Message, "OK");
+                Console.WriteLine(ex);
+            }
+        }
+
+        async void FinaliseConsumable_Clicked(System.Object sender, System.EventArgs e)
+        {
+            var purchase = purchaseStorage.GetFailedPurchase();
+            if (purchase == null)
+            {
+                await DisplayAlert(string.Empty, "No failed purchase to finalise", "OK");
+                return;
+            }
+
+            try
+            {
+                await CrossInAppBilling.Current.ConnectAsync();
+                await CrossInAppBilling.Current.ConsumePurchaseAsync(purchase.ProductId, purchase.PurchaseToken, purchase.Id);
+                await DisplayAlert(string.Empty, "We did it!", "OK");
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert(string.Empty, "Did not finalise purchase: " + ex.Message, "OK");
+                Console.WriteLine(ex);
+            }
+            finally
+            {
+                await CrossInAppBilling.Current.DisconnectAsync();
+            }
+        }
+
+        async void ButtonNonConsumable_Clicked(object sender, EventArgs e)
+		{
+			var id = nonConsumableProductId;
 			try
 			{
                 await CrossInAppBilling.Current.ConnectAsync();
@@ -50,7 +102,7 @@ namespace InAppBillingTests
             }
 		}
 
-		private async void ButtonSub_Clicked(object sender, EventArgs e)
+		async void ButtonSub_Clicked(object sender, EventArgs e)
 		{
 			var id = "renewsub";
 			try
@@ -81,17 +133,17 @@ namespace InAppBillingTests
             }
         }
 
-		private async void ButtonRenewingSub_Clicked(object sender, EventArgs e)
+		async void ButtonRenewingSub_Clicked(object sender, EventArgs e)
 		{
 			
 		}
 
-        private async void ButtonProductInfo_Clicked(object sender, EventArgs e)
+        async void ButtonProductInfo_Clicked(object sender, EventArgs e)
         {
             try
             {
                 await CrossInAppBilling.Current.ConnectAsync();
-                var items = await CrossInAppBilling.Current.GetProductInfoAsync(ItemType.InAppPurchase, "iaptest");
+                var items = await CrossInAppBilling.Current.GetProductInfoAsync(ItemType.InAppPurchase, nonConsumableProductId);
                 Items.Clear();
                 foreach (var item in items)
                     Items.Add(item);
@@ -108,7 +160,7 @@ namespace InAppBillingTests
             }
         }
 
-        private async void ButtonRestore_Clicked(object sender, EventArgs e)
+        async void ButtonRestore_Clicked(object sender, EventArgs e)
 		{
 			try
             {
@@ -135,5 +187,80 @@ namespace InAppBillingTests
                 await CrossInAppBilling.Current.DisconnectAsync();
             }
         }
-	}
+
+        async Task<bool> ProcessPurchase(string receiptData, string productId, string transactionId, bool shouldSucceed)
+        {
+            // Real code should do something here
+            // It would return true on success
+            // But it could throw or return false
+            return shouldSucceed;
+        }
+
+        async Task<InAppBillingPurchase> PurchaseProduct(string productId, ItemType purchaseType, bool shouldSucceed)
+        {
+
+            var billing = CrossInAppBilling.Current;
+            try
+            {
+                var connectionResult = await billing.ConnectAsync();
+                if (!connectionResult)
+                {
+                    throw new Exception("Could not connect to billing service. Please try again later.");
+                }
+
+                var purchase = await billing.PurchaseAsync(productId, purchaseType);
+
+                if (purchase == null)
+                {
+                    throw new Exception("Purchase could not be processed. Please try again later.");
+                }
+
+                // Verify the purchase
+                var verified = await ProcessPurchase(billing.ReceiptData, productId, purchase.Id, shouldSucceed);
+                if (!verified)
+                {
+                    purchaseStorage.SetFailedPurchase(purchase);
+                    throw new Exception("Purchase could not be completed. Please try again later.");
+                }
+
+                if (purchaseType == ItemType.InAppPurchaseConsumable)
+                {
+                    await billing.ConsumePurchaseAsync(productId, purchase.PurchaseToken, purchase.Id);
+                }
+                else
+                {
+                    await billing.AcknowledgePurchaseAsync(purchase.PurchaseToken);
+                }
+
+                // If we got this far, everything's gravy!
+                Debug.WriteLine("Purchase was a success!");
+
+                return purchase;
+            }
+            catch (InAppBillingPurchaseException purchaseEx)
+            {
+                if (purchaseEx.PurchaseError == PurchaseError.UserCancelled)
+                {
+                    Debug.WriteLine("Purchase was cancelled");
+                    return null;
+                }
+                else
+                {
+                    Debug.WriteLine($"Purchase error: {purchaseEx}");
+                }
+                throw purchaseEx;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error: {ex}");
+                throw ex;
+            }
+            finally
+            {
+                await billing.DisconnectAsync();
+            }
+        }
+
+        
+    }
 }

--- a/src/InAppBillingTests/InAppBillingTests/PurchaseStorage.cs
+++ b/src/InAppBillingTests/InAppBillingTests/PurchaseStorage.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Xml.Serialization;
+using Plugin.InAppBilling;
+
+namespace InAppBillingTests
+{
+    public class PurchaseStorage
+    {
+        public PurchaseStorage()
+        {
+        }
+
+        string fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "failedPurchase.xml");
+
+        public struct FailedPurchase
+        {
+            public string Id { get; set; }
+            public DateTime TransactionDateUtc { get; set; }
+            public string ProductId { get; set; }
+            public string PurchaseToken { get; set; }
+        }
+
+        XmlSerializer serializer = new XmlSerializer(typeof(FailedPurchase));
+
+        internal InAppBillingPurchase GetFailedPurchase()
+        {
+            try
+            {
+                using (var file = File.OpenRead(fileName))
+                {
+                    var fp = serializer.Deserialize(file) as FailedPurchase?;
+                    if (fp.HasValue)
+                    {
+                        return new InAppBillingPurchase
+                        {
+                            Id = fp.Value.Id,
+                            TransactionDateUtc = fp.Value.TransactionDateUtc,
+                            ProductId = fp.Value.ProductId,
+                            PurchaseToken = fp.Value.PurchaseToken
+                        };
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        internal void SetFailedPurchase(InAppBillingPurchase purchase)
+        {
+            using (var file = File.OpenWrite(fileName))
+            {
+                var fp = new FailedPurchase
+                {
+                    Id = purchase.Id,
+                    TransactionDateUtc = purchase.TransactionDateUtc,
+                    ProductId = purchase.ProductId,
+                    PurchaseToken = purchase.PurchaseToken
+                };
+                serializer.Serialize(file, fp);
+            }
+        }
+    }
+}
+

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -605,15 +605,13 @@ namespace Plugin.InAppBilling
 				{
 					case SKPaymentTransactionState.Restored:
 					case SKPaymentTransactionState.Purchased:
-						TransactionCompleted?.Invoke(transaction, true);
-
-						onPurchaseSuccess?.Invoke(transaction.ToIABPurchase());
-
 						Finish(transaction);
+						TransactionCompleted?.Invoke(transaction, true);
+						onPurchaseSuccess?.Invoke(transaction.ToIABPurchase());
 						break;
 					case SKPaymentTransactionState.Failed:
-						TransactionCompleted?.Invoke(transaction, false);
 						Finish(transaction);
+						TransactionCompleted?.Invoke(transaction, false);
 						break;
 					default:
 						break;


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #466.

Changes Proposed in this pull request:
- Add a new static property `ShouldAutomaticallyFinishTransactions` to `InAppBillingImplementation` (Apple)
- Only `GetPurchasesAsync` calls `SKPaymentQueue.RestoreCompletedTransactions()`
- `GetPurchasesAsync` now the only method to automatically finish open transactions if `ShouldAutomaticallyFinishTransactions` is false