### PR TITLE
Set the ApplicationUserName for the apple payment

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -396,14 +396,22 @@ namespace Plugin.InAppBilling
 			if (product == null)
 				throw new InAppBillingPurchaseException(PurchaseError.InvalidProduct);
 
-            var payment = SKMutablePayment.PaymentWithProduct(product);
-            payment.ApplicationUsername = applicationUserName;          
-            //var payment = SKPayment.CreateFrom(product);
-            //var payment = SKPayment.CreateFrom((SKProduct)SKProduct.FromObject(new NSString(productId)));
+            if (string.IsNullOrWhiteSpace(applicationUserName))
+            {
+                var payment = SKPayment.CreateFrom(product);
+                //var payment = SKPayment.CreateFrom((SKProduct)SKProduct.FromObject(new NSString(productId)));
+                
+                SKPaymentQueue.DefaultQueue.AddPayment(payment);
+            }
+            else
+            {
+                var payment = SKMutablePayment.PaymentWithProduct(product);
+                payment.ApplicationUsername = applicationUserName;
 
-            SKPaymentQueue.DefaultQueue.AddPayment(payment);
+                SKPaymentQueue.DefaultQueue.AddPayment(payment);
+            }
 
-			return await tcsTransaction.Task;
+            return await tcsTransaction.Task;
 		}
 
         /// <summary>

--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -307,7 +307,7 @@ namespace Plugin.InAppBilling
         public async override Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null)
 		{
 			Init();
-			var p = await PurchaseAsync(productId, itemType);
+			var p = await PurchaseAsync(productId, itemType, obfuscatedAccountId);
 
 			var reference = new DateTime(2001, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
@@ -329,7 +329,7 @@ namespace Plugin.InAppBilling
 		}
 
 
-		async Task<SKPaymentTransaction> PurchaseAsync(string productId, ItemType itemType)
+		async Task<SKPaymentTransaction> PurchaseAsync(string productId, ItemType itemType, string applicationUserName)
 		{
 			var tcsTransaction = new TaskCompletionSource<SKPaymentTransaction>();
 
@@ -396,10 +396,12 @@ namespace Plugin.InAppBilling
 			if (product == null)
 				throw new InAppBillingPurchaseException(PurchaseError.InvalidProduct);
 
-			var payment = SKPayment.CreateFrom(product);
-			//var payment = SKPayment.CreateFrom((SKProduct)SKProduct.FromObject(new NSString(productId)));
-			
-			SKPaymentQueue.DefaultQueue.AddPayment(payment);
+            var payment = SKMutablePayment.PaymentWithProduct(product);
+            payment.ApplicationUsername = applicationUserName;          
+            //var payment = SKPayment.CreateFrom(product);
+            //var payment = SKPayment.CreateFrom((SKProduct)SKProduct.FromObject(new NSString(productId)));
+
+            SKPaymentQueue.DefaultQueue.AddPayment(payment);
 
 			return await tcsTransaction.Task;
 		}
@@ -652,8 +654,9 @@ namespace Plugin.InAppBilling
                 ProductId = p.Payment?.ProductIdentifier ?? string.Empty,
                 ProductIds = new string[] { p.Payment?.ProductIdentifier ?? string.Empty },
                 State = p.GetPurchaseState(),
-				PurchaseToken = finalToken
-			};
+				PurchaseToken = finalToken,
+                Payload = p.Payment?.ApplicationUsername
+            };
 		}
 
 		static DateTime NSDateToDateTimeUtc(NSDate date)


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
Allows to set an ApplicationUserName in the payment, which makes it available in LatestReceiptInfo and in webhooks in AppAccountToken.  (Needs to be a Guid to be persisted)
https://developer.apple.com/documentation/storekit/skmutablepayment/1506088-applicationusername
https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info
https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload
