### PR TITLE
    Fix issue with introductory offer period duration on iOS

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.apple.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.apple.cs
@@ -876,7 +876,7 @@ namespace Plugin.InAppBilling
             {
                 LocalizedPrice = pd.LocalizedPrice(),
                 Price = (pd.Price?.DoubleValue ?? 0) * 1000000d,
-                NumberOfPeriods = (int)pd.NumberOfPeriods,
+                NumberOfPeriods = (int)pd.SubscriptionPeriod.NumberOfUnits,
                 CurrencyCode = pd.PriceLocale?.CurrencyCode ?? string.Empty
             };
 


### PR DESCRIPTION
This pull request is intended to fix an issue with getting introductory offer period duration for iOS subscriptions.

Looks like an issue in StoreKit, but the `NumberOfPeriods` property from `SKProductDiscount` always returns 1, no matter what period is configured for the subscription. I tested it on a native Swift project, the result is exactly the same.

This fix can be used as a workaround, to get the number of periods directly from the `SubscriptionPeriod.NumberOfPeriods ` property, in this case StoreKit always returns the correct value.
