### PR TITLE
Updated methods and packages for setoffertoken

### DIFF
--- a/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
+++ b/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
-    <!--<TargetFrameworks>netstandard2.0;net7.0-android</TargetFrameworks>-->
+    <!--<TargetFrameworks>netstandard2.0;net8.0-android</TargetFrameworks>-->
     <TargetFrameworks>netstandard2.0;MonoAndroid13.0;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.Mac20;net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-tvos;net6.0-macos</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.19041;net6.0-windows10.0.19041;</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
@@ -98,14 +98,14 @@
 
   <ItemGroup Condition=" $(TargetFramework.Contains('-android')) ">
     <Compile Include="**\*.android.cs" />
-    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.0.1.3" />
-    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.15" />
+    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.1.0.1" />
+    <PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.17" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <Compile Include="**\*.android.cs" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.8.0" />
-    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.0.1.3" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
+    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.1.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated `UpgradePurchasedSubscriptionInternalAsync` and `PurchaseAsync` methods in `InAppBilling.android.cs` to handle null or empty `OfferToken`. Simplified network error check in `ConsumePurchaseAsync`. Fixed a formatting issue in `PurchaseAsync`. Commented out target Android version in `Plugin.InAppBilling.csproj` to target .NET 6.0 for multiple platforms. Updated `Xamarin.Android.Google.BillingClient`, `Xamarin.Google.Guava.ListenableFuture`, and `Xamarin.Essentials` packages in the Android and MonoAndroid target frameworks.

Fixes #602