### PR TITLE
ios bugfix for RestoreAsync() that affects GetPurchasedItem()

### DIFF
--- a/src/Plugin.InAppBilling/InAppBilling.ios.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.ios.cs
@@ -283,7 +283,8 @@ namespace Plugin.InAppBilling
 			    // Start receiving restored transactions
 			    SKPaymentQueue.DefaultQueue.RestoreCompletedTransactions();
 
-			    return tcsTransaction.Task;
+                var result = await tcsTransaction.Task;
+                return result;
             }
             finally
             {


### PR DESCRIPTION
bugfix for RestoreAsync(). This change fix GetPurchasedItem() too
tested on iPhone