### PR TITLE
Add error code in exception message of InAppBillingPurchaseException.

### DIFF
--- a/src/Plugin.InAppBilling/Shared/InAppBillingExceptions.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/InAppBillingExceptions.shared.cs
@@ -90,12 +90,12 @@ namespace Plugin.InAppBilling
         /// </summary>
         /// <param name="error"></param>
         /// <param name="ex"></param>
-        public InAppBillingPurchaseException(PurchaseError error, Exception ex) : base("Unable to process purchase.", ex) => PurchaseError = error;
+        public InAppBillingPurchaseException(PurchaseError error, Exception ex) : base($"Unable to process purchase : {error:G}.", ex) => PurchaseError = error;
         /// <summary>
         /// 
         /// </summary>
         /// <param name="error"></param>
-        public InAppBillingPurchaseException(PurchaseError error) : base("Unable to process purchase.") => PurchaseError = error;
+        public InAppBillingPurchaseException(PurchaseError error) : base($"Unable to process purchase : {error:G}.") => PurchaseError = error;
 
         /// <summary>
         /// 


### PR DESCRIPTION
Please take a moment to fill out the following:

When investigation bugs & crashes in AppCenter or Crashanalytics, I don't have the root cause of my InAppBillingPurchaseException but a generic message "Unable to process purchase". It would be nice to have more details.

![image](https://github.com/user-attachments/assets/d0c4ad59-2357-4b1e-95ef-62c190c8532f)



Changes Proposed in this pull request:
- add the error code in the InAppBillingPurchaseException messaeg.- 
