### PR TITLE
Ability to pass subOfferToken for Upgrades

### DIFF
--- a/docs/PurchaseSubscription.md
+++ b/docs/PurchaseSubscription.md
@@ -17,6 +17,7 @@ All purchases go through the `PurchaseAsync` method and you must always `Connect
 /// <param name="itemType">Type of product being requested</param>
 /// <param name="obfuscatedAccountId">Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.</param>
 /// <param name="obfuscatedProfileId">Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.</param>
+/// <param name="subOfferToken"></param>
 /// <param name="cancellationToken">Cancel the request.</param>
 /// <returns>Purchase details</returns>
 /// <exception cref="InAppBillingPurchaseException">If an error occurs during processing</exception>
@@ -87,6 +88,8 @@ If you are on Android you must also now provide functionality to allow users to 
 * iOS: Optional, only obfuscatedAccountId is used at this time. See [https://developer.apple.com/documentation/storekit/skmutablepayment/1506088-applicationusername](ApplicationUsername) on the payment.
 * Android: Optional, see [https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder](Android documentation) for more info
 
+#### subOfferToken
+* Android: If your subscription is set up using basePlans, this is the OfferToken for the basePlan you wish to purchase. You can also pass the OfferToken for a specific offer here. Find the OfferToken via the `GetProductInfoAsync` method in the resulting `InAppBillingProduct.AndroidExtras.SubscriptionOfferDetails[x].OfferToken`.
 
 
 <= Back to [Table of Contents](README.md)

--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -232,6 +232,7 @@ namespace Plugin.InAppBilling
         /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
         /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription</param>
         /// <param name="prorationMode">Proration mode (1 - ImmediateWithTimeProration, 2 - ImmediateAndChargeProratedPrice, 3 - ImmediateWithoutProration, 4 - Deferred)</param>
+        /// <param name="subOfferToken">Offer Token for the matching SubscriptionOfferDetails you're upgrading to (this is obtained from the Base Plan)</param>
         /// <returns>Purchase details</returns>
         public override async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default)
         {
@@ -315,6 +316,7 @@ namespace Plugin.InAppBilling
         /// <param name="itemType">Type of product being requested</param>
         /// <param name="obfuscatedAccountId">Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.</param>
         /// <param name="obfuscatedProfileId">Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.</param>
+        /// <param name="subOfferToken">Offer Token for the matching SubscriptionOfferDetails you're purchasing (this is obtained from the Base Plan)</param>
         /// <returns></returns>
         public async override Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null, string subOfferToken = null, CancellationToken cancellationToken = default)
         {

--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -233,19 +233,19 @@ namespace Plugin.InAppBilling
         /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription</param>
         /// <param name="prorationMode">Proration mode (1 - ImmediateWithTimeProration, 2 - ImmediateAndChargeProratedPrice, 3 - ImmediateWithoutProration, 4 - Deferred)</param>
         /// <returns>Purchase details</returns>
-        public override async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default)
+        public override async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default)
         {
 
             // If we have a current task and it is not completed then return null.
             // you can't try to purchase twice.
             AssertPurchaseTransactionReady();
 
-            var purchase = await UpgradePurchasedSubscriptionInternalAsync(newProductId, purchaseTokenOfOriginalSubscription, prorationMode, cancellationToken);
+            var purchase = await UpgradePurchasedSubscriptionInternalAsync(newProductId, purchaseTokenOfOriginalSubscription, prorationMode, subOfferToken, cancellationToken);
 
             return purchase;
         }
 
-        async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionInternalAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode, CancellationToken cancellationToken)
+        async Task<InAppBillingPurchase> UpgradePurchasedSubscriptionInternalAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode, string subOfferToken = null, CancellationToken cancellationToken = default)
         {
             var itemType = ProductType.Subs;
 
@@ -273,7 +273,7 @@ namespace Plugin.InAppBilling
                 .SetSubscriptionReplacementMode((int)prorationMode)
                 .Build();
 
-            var t = skuDetails.GetSubscriptionOfferDetails()?.FirstOrDefault()?.OfferToken;
+            var t = subOfferToken ?? skuDetails.GetSubscriptionOfferDetails()?.FirstOrDefault()?.OfferToken;
 
 
             var prodDetails = BillingFlowParams.ProductDetailsParams.NewBuilder()

--- a/src/Plugin.InAppBilling/InAppBilling.ios.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.ios.cs
@@ -441,7 +441,7 @@ namespace Plugin.InAppBilling
         /// (iOS not supported) Apple store manages upgrades natively when subscriptions of the same group are purchased.
         /// </summary>
         /// <exception cref="NotImplementedException">iOS not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default) =>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException("iOS not supported. Apple store manages upgrades natively when subscriptions of the same group are purchased.");
 
 

--- a/src/Plugin.InAppBilling/InAppBilling.maccatalyst.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.maccatalyst.cs
@@ -441,7 +441,7 @@ namespace Plugin.InAppBilling
         /// (iOS not supported) Apple store manages upgrades natively when subscriptions of the same group are purchased.
         /// </summary>
         /// <exception cref="NotImplementedException">iOS not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default) =>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException("iOS not supported. Apple store manages upgrades natively when subscriptions of the same group are purchased.");
 
 

--- a/src/Plugin.InAppBilling/InAppBilling.macos.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.macos.cs
@@ -441,7 +441,7 @@ namespace Plugin.InAppBilling
         /// (iOS not supported) Apple store manages upgrades natively when subscriptions of the same group are purchased.
         /// </summary>
         /// <exception cref="NotImplementedException">iOS not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default) =>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException("iOS not supported. Apple store manages upgrades natively when subscriptions of the same group are purchased.");
 
 

--- a/src/Plugin.InAppBilling/InAppBilling.uwp.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.uwp.cs
@@ -116,7 +116,7 @@ namespace Plugin.InAppBilling
         /// (UWP not supported) Upgrade/Downgrade/Change a previously purchased subscription
         /// </summary>
         /// <exception cref="NotImplementedException">UWP not supported</exception>
-        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default) =>
+        public override Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default) =>
             throw new NotImplementedException("UWP not supported.");
 
         /// <summary>

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -100,7 +100,7 @@ namespace Plugin.InAppBilling
         /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription (can not be null)</param>
         /// <param name="prorationMode">Proration mode</param>
         /// <returns>Purchase details</returns>
-        public abstract Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default);
+        public abstract Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Consume a purchase with a purchase token.

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -90,6 +90,7 @@ namespace Plugin.InAppBilling
         /// <param name="itemType">Type of product being requested</param>
         /// <param name="obfuscatedAccountId">Android: Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.</param>
         /// <param name="obfuscatedProfileId">Android: Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.</param>
+        /// <param name="subOfferToken">Android: Specifies an optional OfferToken that is associated to an Offer or the default "Offer" on a BasePlan</param>
         /// <returns>Purchase details</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occurs during processing</exception>
         Task<InAppBillingPurchase> PurchaseAsync(string productId, ItemType itemType, string obfuscatedAccountId = null, string obfuscatedProfileId = null, string subOfferToken = null, CancellationToken cancellationToken = default);
@@ -100,9 +101,10 @@ namespace Plugin.InAppBilling
         /// <param name="newProductId">Sku or ID of product that will replace the old one</param>
         /// <param name="purchaseTokenOfOriginalSubscription">Purchase token of original subscription (can not be null)</param>
         /// <param name="prorationMode">Proration mode (1 - ImmediateWithTimeProration, 2 - ImmediateAndChargeProratedPrice, 3 - ImmediateWithoutProration, 4 - Deferred)</param>
+        /// <param name="subOfferToken">Android: Specifies an optional OfferToken that is associated to an Offer or the default "Offer" on a BasePlan</param>
         /// <returns>Purchase details</returns>
         /// <exception cref="InAppBillingPurchaseException">If an error occurs during processing</exception>
-        Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, CancellationToken cancellationToken = default);
+        Task<InAppBillingPurchase> UpgradePurchasedSubscriptionAsync(string newProductId, string purchaseTokenOfOriginalSubscription, SubscriptionProrationMode prorationMode = SubscriptionProrationMode.ImmediateWithTimeProration, string subOfferToken = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Consume a purchase with a purchase token.


### PR DESCRIPTION
- added ability to pass subOfferToken for upgrades
- updated documentation to some degree

Please take a moment to fill out the following:

Fixes #651  (indirectly). Documentation updated to show that `basePlanId` is achieved via the `subOfferToken` parameter.

Changes Proposed in this pull request:
- minor documentation update
- added `subOfferToken` support/handling to Android `UpgradePurchasedSubscriptionAsync`
- 
