### PR TITLE
Update to v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 ## In-App Billing Plugin for .NET MAUI  and Windows
 
+> Important Note: I do not plan on continuing support for this library. As noted in April of 2025: In App Purchase APIs have always been extremely complex, hard to manage, hard to update, and hard to streamline into a single API. I have enjoyed working and evolving this project over the years, but with StoreKit being deprecated for StoreKit2 and the ever-evolving Android Billing Library that always has massive changes, I simply do not have the time and energy to keep the library up to date. I appreciate everyone that has contributed over and used the library over the years. I encourage forking and evolving the library and of course you can just pull the source code into your project directly. 
+
 A simple In-App Purchase plugin for .NET MAUI and Windows to query item information, purchase items, restore items, and more.
 
 Subscriptions are supported on iOS, Android, and Mac. Windows/UWP/WinUI 3 - does not support subscriptions at this time.
 
 ## Important Version Information
+* v10 now supports .NET 10+ and Android Billing v8
 * v9 now supports .NET 9+ and Android Billing v7
 * v8 now supports .NET 8+ .NET MAUI and Windows Apps.
 * v7 now supports .NET 6+, .NET MAUI, UWP, and Xamarin/Xamarin.Forms projects
@@ -23,7 +26,6 @@ Get started by reading through the [In-App Billing Plugin documentation](https:/
 | ------------------- | :------------------: |
 |iOS for .NET|10+|
 |macCatlyst for .NET |All|
-|tvOS for .NET|10.13.2|
 |Android for .NET|21+|
 |Windows App SDK (WinUI 3) |10+|
 |.NET MAUI|All|

--- a/nuget/readme.txt
+++ b/nuget/readme.txt
@@ -1,5 +1,9 @@
 In-App Billing Plugin for .NET MAUI
 
+> Important Note: I do not plan on continuing support for this library. As noted in April of 2025: In App Purchase APIs have always been extremely complex, hard to manage, hard to update, and hard to streamline into a single API. I have enjoyed working and evolving this project over the years, but with StoreKit being deprecated for StoreKit2 and the ever-evolving Android Billing Library that always has massive changes, I simply do not have the time and energy to keep the library up to date. I appreciate everyone that has contributed over and used the library over the years. I encourage forking and evolving the library and of course you can just pull the source code into your project directly. 
+
+* v10 now supports .NET 10+ and Android Billing v8
+
 Version 9.0+ - .NET 9+
 1. Built against Android Billing v7
 

--- a/src/Plugin.InAppBilling/InAppBilling.android.cs
+++ b/src/Plugin.InAppBilling/InAppBilling.android.cs
@@ -181,9 +181,9 @@ namespace Plugin.InAppBilling
             var skuDetailsParams = QueryProductDetailsParams.NewBuilder().SetProductList(productList);
 
             var skuDetailsResult = await BillingClient.QueryProductDetailsAsync(skuDetailsParams.Build());
-            ParseBillingResult(skuDetailsResult?.Result, IgnoreInvalidProducts);
+            //ParseBillingResult(skuDetailsResult?.ProductDetailsList, IgnoreInvalidProducts);
 
-            return skuDetailsResult.ProductDetails.Select(product => product.ToIAPProduct());
+            return skuDetailsResult.ProductDetailsList.Select(product => product.ToIAPProduct());
         }
 
 
@@ -207,30 +207,7 @@ namespace Plugin.InAppBilling
             return purchasesResult.Purchases.Select(p => p.ToIABPurchase());
         }
 
-        /// <summary>
-        /// Android only: Returns the most recent purchase made by the user for each SKU, even if that purchase is expired, canceled, or consumed.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
-        /// <returns>The current purchases</returns>
-        public override async Task<IEnumerable<InAppBillingPurchase>> GetPurchasesHistoryAsync(ItemType itemType, CancellationToken cancellationToken)
-        {
-            if (BillingClient == null)
-                throw new InAppBillingPurchaseException(PurchaseError.ServiceUnavailable, "You are not connected to the Google Play App store.");
-
-            var skuType = itemType switch
-            {
-                ItemType.InAppPurchase => ProductType.Inapp,
-                ItemType.InAppPurchaseConsumable => ProductType.Inapp,
-                _ => ProductType.Subs
-            };
-
-            var historyParams = QueryPurchaseHistoryParams.NewBuilder().SetProductType(skuType).Build();
-            //TODO: Binding needs updated
-            var purchasesResult = await BillingClient.QueryPurchaseHistoryAsync(historyParams);
-
-
-            return purchasesResult?.PurchaseHistoryRecords?.Select(p => p.ToIABPurchase()) ?? new List<InAppBillingPurchase>();
-        }
+   
 
         /// <summary>
         /// (Android specific) Upgrade/Downgrade/Change a previously purchased subscription
@@ -264,9 +241,9 @@ namespace Plugin.InAppBilling
 
             var skuDetailsResult = await BillingClient.QueryProductDetailsAsync(skuDetailsParams);
 
-            ParseBillingResult(skuDetailsResult.Result);
+            //ParseBillingResult(skuDetailsResult.Result);
 
-            var skuDetails = skuDetailsResult.ProductDetails.FirstOrDefault() ?? throw new ArgumentException($"{newProductId} does not exist");
+            var skuDetails = skuDetailsResult.ProductDetailsList.FirstOrDefault() ?? throw new ArgumentException($"{newProductId} does not exist");
 
             //1 - BillingFlowParams.ProrationMode.ImmediateWithTimeProration
             //2 - BillingFlowParams.ProrationMode.ImmediateAndChargeProratedPrice
@@ -368,10 +345,10 @@ namespace Plugin.InAppBilling
 
             var skuDetailsResult = await BillingClient.QueryProductDetailsAsync(skuDetailsParams.Build());
 
-            ParseBillingResult(skuDetailsResult.Result);
+            //ParseBillingResult(skuDetailsResult.Result);
 
 
-            var skuDetails = skuDetailsResult.ProductDetails.FirstOrDefault() ?? throw new ArgumentException($"{productSku} does not exist");
+            var skuDetails = skuDetailsResult.ProductDetailsList.FirstOrDefault() ?? throw new ArgumentException($"{productSku} does not exist");
             BillingFlowParams.ProductDetailsParams productDetailsParamsList;
 
             if (itemType == ProductType.Subs)

--- a/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
+++ b/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <SingleProject>true</SingleProject>
     <AssemblyName>Plugin.InAppBilling</AssemblyName>
     <RootNamespace>Plugin.InAppBilling</RootNamespace>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>9.0.0.0</AssemblyFileVersion>
-    <Version>9.0.0.0</Version>
+    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>10.0.0.0</AssemblyFileVersion>
+    <Version>10.0.0.0</Version>
     <Authors>James Montemagno</Authors>
     <IsPackable>True</IsPackable>
     <PackageId>Plugin.InAppBilling</PackageId>
@@ -29,7 +29,7 @@
       .NET MAUI and Windows Plugin to In-App Billing. Get item information, purchase items, and restore purchases with a cross-platform API.
       Read the full documenation on the projects page.
     </Description>
-    <Copyright>Copyright 2024</Copyright>
+    <Copyright>Copyright 2025</Copyright>
     <RepositoryUrl>https://github.com/jamesmontemagno/InAppBillingPlugin</RepositoryUrl>
     <PackageReleaseNotes>See: https://github.com/jamesmontemagno/InAppBillingPlugin</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -93,15 +93,15 @@
   <!-- Android -->
 
   <ItemGroup Condition=" $(TargetFramework.Contains('-android')) ">
-    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="7.1.1.4" />
-  <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core">
-    <Version>2.8.7.4</Version>
+    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="8.1.0" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core">
+    <Version>2.9.3</Version>
   </PackageReference>
   </ItemGroup>
 
 
-<ItemGroup Condition=" $(TargetFramework.Contains('net9.0-android')) ">
-    <PackageReference Include="Microsoft.Maui.Essentials" Version="9.0.81" />
+<ItemGroup Condition=" $(TargetFramework.Contains('net10.0-android')) ">
+    <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.11" />
   </ItemGroup>
 
   

--- a/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/BaseInAppBilling.shared.cs
@@ -73,15 +73,6 @@ namespace Plugin.InAppBilling
         public abstract Task<IEnumerable<InAppBillingPurchase>> GetPurchasesAsync(ItemType itemType, CancellationToken cancellationToken = default);
 
 
-
-        /// <summary>
-        /// Android only: Returns the most recent purchase made by the user for each SKU, even if that purchase is expired, canceled, or consumed.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
-        /// <returns>The current purchases</returns>
-        public virtual Task<IEnumerable<InAppBillingPurchase>> GetPurchasesHistoryAsync(ItemType itemType, CancellationToken cancellationToken = default) =>
-            Task.FromResult<IEnumerable<InAppBillingPurchase>>(new List<InAppBillingPurchase>());
-
         /// <summary>
         /// Purchase a specific product or subscription
         /// </summary>

--- a/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
+++ b/src/Plugin.InAppBilling/Shared/IInAppBilling.shared.cs
@@ -77,13 +77,6 @@ namespace Plugin.InAppBilling
 
 
         /// <summary>
-        /// Android only: Returns the most recent purchase made by the user for each SKU, even if that purchase is expired, canceled, or consumed.
-        /// </summary>
-        /// <param name="itemType">Type of product</param>
-        /// <returns>The current purchases</returns>
-        Task<IEnumerable<InAppBillingPurchase>> GetPurchasesHistoryAsync(ItemType itemType, CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Purchase a specific product or subscription
         /// </summary>
         /// <param name="productId">Sku or ID of product</param>


### PR DESCRIPTION
Update to v10: .NET 10+ and Android Billing v8 support

- Added a note about discontinuing library support after April 2025.
- Updated README and readme.txt with version compatibility details.
- Migrated to .NET 10+ and updated Android Billing Client to v8.1.0.
- Removed `GetPurchasesHistoryAsync` method from Android implementation.
- Adjusted `GetProductInfoAsync`, `PurchaseAsync`, and subscription upgrade methods to use `ProductDetailsList`.
- Updated project metadata: assembly version to 10.0.0.0, copyright year to 2025.
- Upgraded dependencies, including AndroidX Lifecycle LiveData Core and Microsoft.Maui.Essentials.
- Simplified API by deprecating certain features and encouraging forking.

Please take a moment to fill out the following:

Fixes # .

Changes Proposed in this pull request:
-
-
- 
